### PR TITLE
Coded Response Type on Advanced Tab

### DIFF
--- a/webapp-mgmt/cas-management-webapp/src/app/form/form.module.ts
+++ b/webapp-mgmt/cas-management-webapp/src/app/form/form.module.ts
@@ -71,6 +71,7 @@ import { NameidComponent } from './samlclient/nameid/nameid.component';
 import { MappedComponent } from './attribute-release-filters/mapped/mapped.component';
 import {TabOIDCComponent} from './tab-oidc/tab-oidc.component';
 import {InvalidDomainDirective} from './serviceid/invalid-domain.directive';
+import { ResponsetypeComponent } from './responsetype/responsetype.component';
 
 
 @NgModule({
@@ -145,7 +146,8 @@ import {InvalidDomainDirective} from './serviceid/invalid-domain.directive';
     OptionalComponent,
     NameidComponent,
     MappedComponent,
-    InvalidDomainDirective
+    InvalidDomainDirective,
+    ResponsetypeComponent
   ],
   providers: [
     FormResolve,

--- a/webapp-mgmt/cas-management-webapp/src/app/form/pubkey/pubkey.component.html
+++ b/webapp-mgmt/cas-management-webapp/src/app/form/pubkey/pubkey.component.html
@@ -6,7 +6,8 @@
                                data.service.attributeReleasePolicy.authorizedToReleaseProxyGrantingTicket"
            i18n-placeholder="services.form.label.pubKey.location"
            [placeholder]="messages.services_form_label_pubKey_location"
-           [(ngModel)]="data.service.publicKey.location">
+           [(ngModel)]="location"
+           (change)="changeLocation()">
   </mat-form-field>
   <mat-icon style="font-size: medium"
            i18n-matTooltip="services.form.tooltip.pubKey.location"
@@ -18,7 +19,9 @@
   <mat-form-field class="textInput">
     <mat-select i18n-placeholder="services.form.label.pubKey.algorithm"
                 [placeholder]="messages.services_form_label_pubKey_algorithm"
-                [(ngModel)]="data.service.publicKey.algorithm">
+                [(ngModel)]="algorithm"
+                (selectionChange)="changeAlgorithm()">
+      <mat-option></mat-option>
       <mat-option value="RSA">RSA</mat-option>
     </mat-select>
   </mat-form-field>

--- a/webapp-mgmt/cas-management-webapp/src/app/form/pubkey/pubkey.component.ts
+++ b/webapp-mgmt/cas-management-webapp/src/app/form/pubkey/pubkey.component.ts
@@ -10,11 +10,39 @@ import {Data} from '../data';
 })
 export class PubkeyComponent implements OnInit {
 
+  algorithm: String;
+  location: String;
+
   constructor(public messages: Messages,
               public data: Data) {
   }
 
   ngOnInit() {
+    if (this.data.service.publicKey) {
+      this.algorithm = this.data.service.publicKey.algorithm;
+      this.location = this.data.service.publicKey.location;
+    }
+  }
+
+  changeLocation() {
+    if (this.algorithm || this.location) {
+      this.checkPubKey();
+      this.data.service.publicKey.location = this.location;
+    } else {
+      this.data.service.publicKey = null;
+    }
+  }
+
+  changeAlgorithm() {
+    if (this.algorithm || this.location) {
+      this.checkPubKey();
+      this.data.service.publicKey.algorithm = this.algorithm;
+    } else {
+      this.data.service.publicKey = null;
+    }
+  }
+
+  checkPubKey() {
     if (!this.data.service.publicKey) {
       this.data.service.publicKey = new RegisteredServicePublicKeyImpl();
     }

--- a/webapp-mgmt/cas-management-webapp/src/app/form/responsetype/responsetype.component.html
+++ b/webapp-mgmt/cas-management-webapp/src/app/form/responsetype/responsetype.component.html
@@ -1,0 +1,16 @@
+<div>
+    <mat-form-field class="textInput">
+        <mat-select i18n-placeholder="services.form.label.responseType"
+                    [placeholder]="messages.services_form_label_responseType"
+                    [(ngModel)]="data.service.responseType">
+            <mat-option></mat-option>
+            <mat-option value="POST">POST</mat-option>
+            <mat-option value="REDIRECT">REDIRECT</mat-option>
+            <mat-option value="HEADER">HEADER</mat-option>
+        </mat-select>
+    </mat-form-field>
+    <mat-icon style="font-size: medium"
+              i18n-matTooltip="services.form.tooltip.responseType"
+              [matTooltip]="messages.services_form_tooltip_responseType">help
+    </mat-icon>
+</div>

--- a/webapp-mgmt/cas-management-webapp/src/app/form/responsetype/responsetype.component.spec.ts
+++ b/webapp-mgmt/cas-management-webapp/src/app/form/responsetype/responsetype.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ResponsetypeComponent } from './responsetype.component';
+
+describe('ResponsetypeComponent', () => {
+  let component: ResponsetypeComponent;
+  let fixture: ComponentFixture<ResponsetypeComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ ResponsetypeComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ResponsetypeComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/webapp-mgmt/cas-management-webapp/src/app/form/responsetype/responsetype.component.ts
+++ b/webapp-mgmt/cas-management-webapp/src/app/form/responsetype/responsetype.component.ts
@@ -1,0 +1,19 @@
+import { Component, OnInit } from '@angular/core';
+import {Data} from '../data';
+import {Messages} from '../../messages';
+
+@Component({
+  selector: 'app-responsetype',
+  templateUrl: './responsetype.component.html',
+  styleUrls: ['./responsetype.component.css']
+})
+export class ResponsetypeComponent implements OnInit {
+
+  constructor(public messages: Messages,
+              public data: Data) {
+  }
+
+  ngOnInit() {
+  }
+
+}

--- a/webapp-mgmt/cas-management-webapp/src/app/form/tab-advanced/tab-advanced.component.html
+++ b/webapp-mgmt/cas-management-webapp/src/app/form/tab-advanced/tab-advanced.component.html
@@ -7,6 +7,7 @@
       <div class="cardContent">
         <app-evalorder></app-evalorder>
         <app-reqhandlers></app-reqhandlers>
+        <app-responsetype></app-responsetype>
       </div>
     </mat-card>
     <mat-card class="tabCard">

--- a/webapp-mgmt/cas-management-webapp/src/app/messages.ts
+++ b/webapp-mgmt/cas-management-webapp/src/app/messages.ts
@@ -78,6 +78,7 @@ export class Messages {
  readonly services_form_label_name = 'Service Name';
  readonly services_form_label_description = 'Description';
  readonly services_form_label_type = 'Service Type';
+ readonly services_form_label_responseType = 'Response Type';
  readonly services_form_label_casClients = 'CAS Client';
  readonly services_form_label_renewalDate = 'Renewal Date';
  readonly services_form_label_theme = 'Theme';
@@ -252,6 +253,7 @@ export class Messages {
  readonly services_form_tooltip_consumer_url = 'A url that represents a WS Federation Consumer URL';
  readonly services_form_tooltip_name = 'The service name.';
  readonly services_form_tooltip_description = 'The service description.';
+ readonly services_form_tooltip_responseType = 'Defines how CAS should respond to requests for this service.';
  readonly services_form_tooltip_type = 'Everything that applies to a CAS client applies to an OAuth client too, but OAuth clients have a few more extra settings.';
  readonly services_form_tooltip_casClients = 'List any known CAS Clients used by this service.(mod_auth_cas...)';
  readonly services_form_tooltip_renewalDate = 'This is the date by which the service will need to verified active by the service contacts.';


### PR DESCRIPTION
PR adds the ability for the user to define the responseType that CAS should use when responding for this service.  This field was added to the Advanced tab for the form.  

Also includes a change to lazy init the Public Key until values are defined.