### PR TITLE
Import service from JSON/YAML

### DIFF
--- a/webapp-mgmt/cas-management-webapp-support/src/main/java/org/apereo/cas/mgmt/services/web/ForwardingController.java
+++ b/webapp-mgmt/cas-management-webapp-support/src/main/java/org/apereo/cas/mgmt/services/web/ForwardingController.java
@@ -28,7 +28,8 @@ public class ForwardingController {
             "search/{query:.*}",
             "history/{fileName:.*}",
             "json/{fileId:.*}",
-            "localChanges"})
+            "localChanges",
+            "import"})
     public String forward() {
         return "manage.html";
     }

--- a/webapp-mgmt/cas-management-webapp-support/src/main/java/org/apereo/cas/mgmt/services/web/ManageRegisteredServicesMultiActionController.java
+++ b/webapp-mgmt/cas-management-webapp-support/src/main/java/org/apereo/cas/mgmt/services/web/ManageRegisteredServicesMultiActionController.java
@@ -359,7 +359,7 @@ public class ManageRegisteredServicesMultiActionController extends AbstractManag
             }
             svc.setId(-1);
             return new ResponseEntity<>(svc, HttpStatus.OK);
-        } catch (Exception e) {
+        } catch (final Exception e) {
             response.setStatus(HttpStatus.INTERNAL_SERVER_ERROR.value());
             throw new Exception("Failed to parse Service");
         }

--- a/webapp-mgmt/cas-management-webapp-support/src/main/java/org/apereo/cas/mgmt/services/web/ManageRegisteredServicesMultiActionController.java
+++ b/webapp-mgmt/cas-management-webapp-support/src/main/java/org/apereo/cas/mgmt/services/web/ManageRegisteredServicesMultiActionController.java
@@ -16,6 +16,8 @@ import org.apereo.cas.mgmt.services.web.factory.RepositoryFactory;
 import org.apereo.cas.services.RegexRegisteredService;
 import org.apereo.cas.services.RegisteredService;
 import org.apereo.cas.services.ServicesManager;
+import org.apereo.cas.services.util.DefaultRegisteredServiceJsonSerializer;
+import org.apereo.cas.services.util.RegisteredServiceYamlSerializer;
 import org.apereo.cas.util.CasVersion;
 import org.apereo.cas.util.RegexUtils;
 import org.springframework.http.HttpStatus;
@@ -330,6 +332,37 @@ public class ManageRegisteredServicesMultiActionController extends AbstractManag
         return new ResponseEntity<>(new String[]{CasVersion.getVersion(),
                                     this.getClass().getPackage().getImplementationVersion()},
                                     HttpStatus.OK);
+    }
+
+    /**
+     * Parses the passes json or yaml string into a Registered Service object and returns to the client.
+     * The id of the service will be set to -1 to force adding a new assigned id if saved.
+     *
+     * @param request - the request
+     * @param response - the response
+     * @param service - the json/yaml string of the service.
+     * @return - the parsed RegisteredService.
+     * @throws Exception - failed
+     */
+    @PostMapping(value = "import", consumes = MediaType.TEXT_PLAIN_VALUE)
+    public ResponseEntity<RegisteredService> importService(final HttpServletRequest request,
+                                                           final HttpServletResponse response,
+                                                           final @RequestBody String service) throws Exception {
+        try {
+            final RegisteredService svc;
+            if (service.startsWith("{")) {
+                final DefaultRegisteredServiceJsonSerializer serializer = new DefaultRegisteredServiceJsonSerializer();
+                svc = serializer.from(service);
+            } else {
+                final RegisteredServiceYamlSerializer yamlSerializer = new RegisteredServiceYamlSerializer();
+                svc = yamlSerializer.from(service);
+            }
+            svc.setId(-1);
+            return new ResponseEntity<>(svc, HttpStatus.OK);
+        } catch (Exception e) {
+            response.setStatus(HttpStatus.INTERNAL_SERVER_ERROR.value());
+            throw new Exception("Failed to parse Service");
+        }
     }
 }
 

--- a/webapp-mgmt/cas-management-webapp/src/app/app-routing.module.ts
+++ b/webapp-mgmt/cas-management-webapp/src/app/app-routing.module.ts
@@ -21,6 +21,7 @@ import {SubmitsComponent} from './submits/submits.component';
 import {ChangesComponent} from './changes/changes.component';
 import {ChangesResolve} from './changes/changes.resolover';
 import {NotesComponent} from './notes/notes.component';
+import {ImportComponent} from './import/import.component';
 
 @NgModule({
   imports: [
@@ -111,6 +112,10 @@ import {NotesComponent} from './notes/notes.component';
       {
         path: 'notes/:id',
         component: NotesComponent
+      },
+      {
+        path: 'import',
+        component: ImportComponent
       }
     ]),
   ],

--- a/webapp-mgmt/cas-management-webapp/src/app/app.module.ts
+++ b/webapp-mgmt/cas-management-webapp/src/app/app.module.ts
@@ -36,6 +36,8 @@ import {NotesModule} from './notes/notes.module';
 import {RejectComponent} from './reject/reject.component';
 import {AcceptComponent} from './accept/accept.component';
 import {FooterService} from './footer/footer.service';
+import { ImportComponent } from './import/import.component';
+import {ImportService} from './import/import.service';
 
 
 @NgModule({
@@ -68,7 +70,8 @@ import {FooterService} from './footer/footer.service';
     InitComponent,
     LocalChangesComponent,
     FooterComponent,
-    YamlComponent
+    YamlComponent,
+    ImportComponent
   ],
   entryComponents: [
     DeleteComponent,
@@ -82,7 +85,8 @@ import {FooterService} from './footer/footer.service';
     HeaderService,
     UserService,
     YamlResolver,
-    FooterService
+    FooterService,
+    ImportService
   ],
   bootstrap: [AppComponent]
 })

--- a/webapp-mgmt/cas-management-webapp/src/app/controls/controls.component.html
+++ b/webapp-mgmt/cas-management-webapp/src/app/controls/controls.component.html
@@ -1,4 +1,20 @@
 <div>
+  <div style="display: inline" *ngIf="showOpen">
+    <button mat-button (click)="open.click();">
+      <mat-icon>file_upload</mat-icon>
+      <ng-container i18n>Open</ng-container>
+    </button>
+    <button mat-button (click)="save.emit()">
+      <mat-icon>add_circle</mat-icon>
+      <ng-container i18n>Import</ng-container>
+    </button>
+    <button mat-button (click)="goBack();">
+      <mat-icon>cancel</mat-icon>
+      <ng-container i18n="services.form.button.cancel">
+        {{ messages.services_form_button_cancel }}
+      </ng-container>
+    </button>
+  </div>
   <div style="display:inline;" *ngIf="showEdit">
     <button mat-button (click)="save.emit();">
       <mat-icon>save</mat-icon>
@@ -41,4 +57,5 @@
     </button>
   </div>
 </div>
+<input #open type="file" (change)="openFile.emit($event);" style="display:none;">
 

--- a/webapp-mgmt/cas-management-webapp/src/app/controls/controls.component.ts
+++ b/webapp-mgmt/cas-management-webapp/src/app/controls/controls.component.ts
@@ -23,11 +23,17 @@ export class ControlsComponent implements OnInit {
   @Input()
   showRefresh: boolean;
 
+  @Input()
+  showOpen: boolean;
+
   @ViewChild('publishModal')
   submitComp: PublishComponent;
 
   @Output()
   save: EventEmitter<void> = new EventEmitter<void>();
+
+  @Output()
+  openFile: EventEmitter<any> = new EventEmitter<any>();
 
   @Output()
   refresh: EventEmitter<void> = new EventEmitter<void>();

--- a/webapp-mgmt/cas-management-webapp/src/app/form/form-routing.module.ts
+++ b/webapp-mgmt/cas-management-webapp/src/app/form/form-routing.module.ts
@@ -136,6 +136,15 @@ const childRoutes: Routes = [
           resp: FormResolve
         },
         children: childRoutes
+      },
+      {
+        path: 'importService',
+        component: FormComponent,
+        children: childRoutes,
+        data: {
+          import: true
+        }
+
       }
     ])
   ],

--- a/webapp-mgmt/cas-management-webapp/src/app/form/form.component.ts
+++ b/webapp-mgmt/cas-management-webapp/src/app/form/form.component.ts
@@ -20,6 +20,7 @@ import {MatSnackBar, MatTabGroup} from '@angular/material';
 import {GrouperRegisteredServiceAccessStrategy} from '../../domain/access-strategy';
 import {RegisteredServiceRegexAttributeFilter} from '../../domain/attribute-filter';
 import {UserService} from '../user.service';
+import {ImportService} from '../import/import.service';
 
 enum Tabs {
   BASICS,
@@ -54,6 +55,7 @@ export class FormComponent implements OnInit {
               private route: ActivatedRoute,
               private router: Router,
               private service: FormService,
+              private importService: ImportService,
               public data: Data,
               private location: Location,
               public snackBar: MatSnackBar,
@@ -63,17 +65,22 @@ export class FormComponent implements OnInit {
   ngOnInit() {
     this.view = this.route.snapshot.data.view;
     this.data.view = this.view;
-    this.route.data
-      .subscribe((data: { resp: AbstractRegisteredService[]}) => {
-        if (data.resp && data.resp[1]) {
-          this.data.original = data.resp[1];
-        }
-        if (data.resp && data.resp[0]) {
-          this.loadService(data.resp[0]);
-          this.goto(Tabs.BASICS)
-        }
+    if (this.route.snapshot.data.import) {
+      this.loadService(this.importService.service);
+      this.goto(Tabs.BASICS);
+    } else {
+      this.route.data
+        .subscribe((data: { resp: AbstractRegisteredService[] }) => {
+          if (data.resp && data.resp[1]) {
+            this.data.original = data.resp[1];
+          }
+          if (data.resp && data.resp[0]) {
+            this.loadService(data.resp[0]);
+            this.goto(Tabs.BASICS)
+          }
 
-      });
+        });
+    }
   }
 
   goto(tab: Tabs) {

--- a/webapp-mgmt/cas-management-webapp/src/app/header/header.component.html
+++ b/webapp-mgmt/cas-management-webapp/src/app/header/header.component.html
@@ -45,6 +45,10 @@
         {{ messages.management_services_header_navbar_navitem_addNewService }}
       </span>
   </button>
+  <button mat-menu-item routerLink="/import">
+    <mat-icon>add_circle</mat-icon>
+    <ng-container i18n>Import Service</ng-container>
+  </button>
   <button mat-menu-item routerLink="/localChanges">
     <mat-icon>build</mat-icon>
     <ng-container i18n>Working Changes</ng-container>

--- a/webapp-mgmt/cas-management-webapp/src/app/import/import.component.html
+++ b/webapp-mgmt/cas-management-webapp/src/app/import/import.component.html
@@ -1,0 +1,18 @@
+<div style="display:flex;margin-bottom:10px;margin-left:25px;margin-right:25px;">
+  <div style="padding-top: 10px;">
+    <mat-icon style="padding-top: 3px;">code</mat-icon>
+    <h4 style="display: inline;position: relative;top: -5px;">
+      <ng-container i18n>
+        Import Service
+      </ng-container>
+    </h4>
+  </div>
+  <div style="flex: 1 1 auto"></div>
+  <div>
+    <app-controls showOpen="true" (save)="save()" (openFile)="getFile($event)"></app-controls>
+  </div>
+</div>
+
+<div style="height:600px;margin-right:25px;margin-left:25px;">
+  <app-editor [file]="file" mode="hjson" theme="eclipse" style="width:100%;height:100%;"></app-editor>
+</div>

--- a/webapp-mgmt/cas-management-webapp/src/app/import/import.component.spec.ts
+++ b/webapp-mgmt/cas-management-webapp/src/app/import/import.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ImportComponent } from './import.component';
+
+describe('ImportComponent', () => {
+  let component: ImportComponent;
+  let fixture: ComponentFixture<ImportComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ ImportComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ImportComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/webapp-mgmt/cas-management-webapp/src/app/import/import.component.ts
+++ b/webapp-mgmt/cas-management-webapp/src/app/import/import.component.ts
@@ -1,0 +1,44 @@
+import {Component, OnInit, ViewChild} from '@angular/core';
+import {Messages} from '../messages';
+import {ImportService} from './import.service';
+import {Router} from '@angular/router';
+import {EditorComponent} from '../editor.component';
+
+@Component({
+  selector: 'app-import',
+  templateUrl: './import.component.html',
+  styleUrls: ['./import.component.css']
+})
+export class ImportComponent implements OnInit {
+
+  file: String;
+
+  @ViewChild(EditorComponent)
+  editor: EditorComponent;
+
+  constructor(public messages: Messages,
+              public service: ImportService,
+              public router: Router) {
+
+  }
+
+  ngOnInit() {
+  }
+
+  save() {
+    this.service.import(this.editor.getFile()).then(resp => {
+      this.router.navigate(['importService']);
+    }).catch(e => alert('The system was not able to parse your imported service as a valid Registered Service.'));
+  }
+
+  getFile(evt: Event) {
+    let input: HTMLInputElement = evt.srcElement as HTMLInputElement;
+    var reader = new FileReader();
+    reader.onload = (function(fe:ImportComponent) {
+      return function (e:Event) {
+        fe.file = <String> reader.result;
+      };
+    })(this);
+    reader.readAsText(input.files[0]);
+  }
+}

--- a/webapp-mgmt/cas-management-webapp/src/app/import/import.component.ts
+++ b/webapp-mgmt/cas-management-webapp/src/app/import/import.component.ts
@@ -32,10 +32,10 @@ export class ImportComponent implements OnInit {
   }
 
   getFile(evt: Event) {
-    let input: HTMLInputElement = evt.srcElement as HTMLInputElement;
-    var reader = new FileReader();
-    reader.onload = (function(fe:ImportComponent) {
-      return function (e:Event) {
+    const input: HTMLInputElement = evt.srcElement as HTMLInputElement;
+    const reader = new FileReader();
+    reader.onload = (function(fe: ImportComponent) {
+      return function (e: Event) {
         fe.file = <String> reader.result;
       };
     })(this);

--- a/webapp-mgmt/cas-management-webapp/src/app/import/import.service.ts
+++ b/webapp-mgmt/cas-management-webapp/src/app/import/import.service.ts
@@ -6,12 +6,12 @@ import {HttpClient} from '@angular/common/http';
 @Injectable()
 export class ImportService {
 
-  constructor(private http: HttpClient) {}
-
   service: AbstractRegisteredService;
 
+  constructor(private http: HttpClient) {}
+
   import(file: String): Promise<AbstractRegisteredService> {
-    return this.http.post<AbstractRegisteredService>("import", file)
+    return this.http.post<AbstractRegisteredService>('import', file)
       .toPromise()
       .then(resp => {
         this.service = resp;

--- a/webapp-mgmt/cas-management-webapp/src/app/import/import.service.ts
+++ b/webapp-mgmt/cas-management-webapp/src/app/import/import.service.ts
@@ -1,0 +1,26 @@
+import {Service} from '../service';
+import {Injectable} from '@angular/core';
+import {AbstractRegisteredService, RegisteredService} from '../../domain/registered-service';
+import {HttpClient} from '@angular/common/http';
+
+@Injectable()
+export class ImportService {
+
+  constructor(private http: HttpClient) {}
+
+  service: AbstractRegisteredService;
+
+  import(file: String): Promise<AbstractRegisteredService> {
+    return this.http.post<AbstractRegisteredService>("import", file)
+      .toPromise()
+      .then(resp => {
+        this.service = resp;
+        return resp;
+      }).catch(this.handleError);
+  }
+
+  handleError(e: any): Promise<any> {
+    console.log('An error occurred : ' + e.message);
+    return Promise.reject(e.message || e);
+  }
+}


### PR DESCRIPTION
This PR adds the ability to import a service into the CAS Service Registry using either JSON or YAML formats.  
* User can choose to open a file from their local computer or paste the contents directly into the browser.
* User can edit the JSON or YAML in place before importing.
* Importing a service will bring the Service up in the Form edit view.  Here the user can edit the service and then save the Service to the registry.
* When a service is imported, the assigned id is always set to -1 to ensure a new service is created.

