### PR TITLE
Adds Synchronize option for Admins

### DIFF
--- a/webapp-mgmt/cas-management-webapp-support/src/main/java/org/apereo/cas/mgmt/services/web/ManageRegisteredServicesMultiActionController.java
+++ b/webapp-mgmt/cas-management-webapp-support/src/main/java/org/apereo/cas/mgmt/services/web/ManageRegisteredServicesMultiActionController.java
@@ -376,6 +376,7 @@ public class ManageRegisteredServicesMultiActionController extends AbstractManag
         config.setMgmtType(casProperties.getServiceRegistry().getManagementType().toString());
         config.setVersionControl(casProperties.getMgmt().isEnableVersionControl());
         config.setDelegatedMgmt(casProperties.getMgmt().isEnableDelegatedMgmt());
+        config.setSyncScript(casProperties.getMgmt().getSyncScript() != null);
         return new ResponseEntity<>(config, HttpStatus.OK);
     }
 }

--- a/webapp-mgmt/cas-management-webapp-support/src/main/java/org/apereo/cas/mgmt/services/web/ServiceRepsositoryController.java
+++ b/webapp-mgmt/cas-management-webapp-support/src/main/java/org/apereo/cas/mgmt/services/web/ServiceRepsositoryController.java
@@ -138,6 +138,25 @@ public class ServiceRepsositoryController {
     }
 
     /**
+     * Method to run sync script outside of publish.
+     *
+     * @param request - the request
+     * @param response - ther resposne
+     * @return - status
+     * @throws Exception - failed
+     */
+    @GetMapping("sync")
+    public ResponseEntity<String> sync(final HttpServletRequest request,
+                                       final HttpServletResponse response) throws Exception {
+        final CasUserProfile casUserProfile = casUserProfileFactory.from(request, response);
+        if (casUserProfile.isAdministrator()) {
+            runSyncScript();
+            return new ResponseEntity<>("Services Synced", HttpStatus.OK);
+        }
+        throw new Exception("You are not authorized for this operation");
+
+    }
+    /**
      * If a syncScript is configured it will be executed.
      *
      * @throws Exception - failed.

--- a/webapp-mgmt/cas-management-webapp-support/src/main/java/org/apereo/cas/mgmt/services/web/beans/AppConfig.java
+++ b/webapp-mgmt/cas-management-webapp-support/src/main/java/org/apereo/cas/mgmt/services/web/beans/AppConfig.java
@@ -17,4 +17,5 @@ public class AppConfig {
     private String mgmtType;
     private boolean versionControl;
     private boolean delegatedMgmt;
+    private boolean syncScript;
 }

--- a/webapp-mgmt/cas-management-webapp/src/app/controls/controls.service.ts
+++ b/webapp-mgmt/cas-management-webapp/src/app/controls/controls.service.ts
@@ -45,4 +45,8 @@ export class ControlsService extends Service {
     this.get<GitStatus>('gitStatus').then(resp => this.status = resp);
   }
 
+  sync(): Promise<String> {
+    return this.getText("sync");
+  }
+
 }

--- a/webapp-mgmt/cas-management-webapp/src/app/header/header.component.html
+++ b/webapp-mgmt/cas-management-webapp/src/app/header/header.component.html
@@ -53,6 +53,10 @@
     <mat-icon>build</mat-icon>
     <ng-container i18n>Working Changes</ng-container>
   </button>
+  <button *ngIf="isAdmin() && isSyncScript()" mat-menu-item (click)="sync()">
+    <mat-icon>sync</mat-icon>
+    <ng-container i18n>Synchronize</ng-container>
+  </button>
   <button mat-menu-item target="_self" id="logoutUrlLink" (click)="logout()">
     <mat-icon>exit_to_app</mat-icon>
     <ng-container i18n="management.services.header.navbar.navitem.logout">

--- a/webapp-mgmt/cas-management-webapp/src/app/header/header.component.ts
+++ b/webapp-mgmt/cas-management-webapp/src/app/header/header.component.ts
@@ -5,6 +5,7 @@ import {Location} from '@angular/common';
 import {UserService} from '../user.service';
 import {ControlsService} from '../controls/controls.service';
 import {AppConfigService} from '../app-config.service';
+import {MatSnackBar} from '@angular/material';
 
 @Component({
   selector: 'app-header',
@@ -22,7 +23,8 @@ export class HeaderComponent implements OnInit {
               public location: Location,
               public appService: AppConfigService,
               public userService: UserService,
-              public controlsService: ControlsService) { }
+              public controlsService: ControlsService,
+              public snackBar: MatSnackBar) { }
 
   ngOnInit() {
   }
@@ -37,6 +39,18 @@ export class HeaderComponent implements OnInit {
 
   isAdmin(): boolean {
     return this.userService.user && this.userService.user.administrator;
+  }
+
+  isSyncScript(): boolean {
+    return this.appService.config.syncScript;
+  }
+
+  sync() {
+    this.controlsService.sync().then(resp => {
+      this.snackBar.open("Services Synchronized", "Dismiss", {
+        duration: 5000
+      });
+    });
   }
 
 }

--- a/webapp-mgmt/cas-management-webapp/src/domain/app-config.ts
+++ b/webapp-mgmt/cas-management-webapp/src/domain/app-config.ts
@@ -2,4 +2,5 @@ export class AppConfig {
   mgmtType = 'DEFAULT';
   versionControl: boolean;
   delegatedMgmt: boolean;
+  syncScript: boolean;
 }


### PR DESCRIPTION
This PR adds the ability for an administrator to execute the sync script outside of publish.  The option is only available to admins when the app is configured to execute a sync script to push changes to CAS Server nodes.  