### PR TITLE
Adds Screen to view commit log and changes in each commit

### DIFF
--- a/webapp-mgmt/cas-management-webapp-support/src/main/java/org/apereo/cas/mgmt/services/web/beans/Commit.java
+++ b/webapp-mgmt/cas-management-webapp-support/src/main/java/org/apereo/cas/mgmt/services/web/beans/Commit.java
@@ -23,4 +23,9 @@ public class Commit {
      * Commit message of the commit.
      */
     private String text;
+
+    /**
+     * Time commit occurred.
+     */
+    private String commitTime;
 }

--- a/webapp-mgmt/cas-management-webapp-support/src/main/java/org/apereo/cas/mgmt/services/web/beans/Diff.java
+++ b/webapp-mgmt/cas-management-webapp-support/src/main/java/org/apereo/cas/mgmt/services/web/beans/Diff.java
@@ -3,6 +3,7 @@ package org.apereo.cas.mgmt.services.web.beans;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.eclipse.jgit.lib.ObjectId;
 
 import java.io.Serializable;
 
@@ -36,4 +37,29 @@ public class Diff implements Serializable {
      * Type of change.
      */
     private String changeType;
+
+    /**
+     * Who committed the change.
+     */
+    private String committer;
+
+    /**
+     * Time commit occurred.
+     */
+    private String commitTime;
+
+    /**
+     * Id of commit.
+     */
+    private String commit;
+
+    public Diff(final String path,
+                final ObjectId oldId,
+                final ObjectId newId,
+                final String changeType) {
+        this.path = path;
+        this.oldId = ObjectId.toString(oldId);
+        this.newId = ObjectId.toString(newId);
+        this.changeType = changeType;
+    }
 }

--- a/webapp-mgmt/cas-management-webapp/src/app/app-config.service.ts
+++ b/webapp-mgmt/cas-management-webapp/src/app/app-config.service.ts
@@ -8,6 +8,7 @@ export class AppConfigService {
   config: AppConfig = new AppConfig();
 
   constructor(private http: HttpClient) {
+    this.getConfig();
   }
 
   getConfig(): Promise<AppConfig> {

--- a/webapp-mgmt/cas-management-webapp/src/app/app-routing.module.ts
+++ b/webapp-mgmt/cas-management-webapp/src/app/app-routing.module.ts
@@ -22,6 +22,9 @@ import {ChangesComponent} from './changes/changes.component';
 import {ChangesResolve} from './changes/changes.resolover';
 import {NotesComponent} from './notes/notes.component';
 import {ImportComponent} from './import/import.component';
+import {RepoHistoryComponent} from './repo-history/repo-history.component';
+import {CommitHistoryComponent} from './commit-history/commit-history.component';
+import {CommitHistoryResolve} from './commit-history/commit-history.resolver';
 
 @NgModule({
   imports: [
@@ -116,6 +119,17 @@ import {ImportComponent} from './import/import.component';
       {
         path: 'import',
         component: ImportComponent
+      },
+      {
+        path: 'repo-history',
+        component: RepoHistoryComponent
+      },
+      {
+        path: 'commit-history/:id',
+        component: CommitHistoryComponent,
+        resolve: {
+          resp: CommitHistoryResolve
+        }
       }
     ]),
   ],

--- a/webapp-mgmt/cas-management-webapp/src/app/app.module.ts
+++ b/webapp-mgmt/cas-management-webapp/src/app/app.module.ts
@@ -38,6 +38,9 @@ import {FooterService} from './footer/footer.service';
 import { ImportComponent } from './import/import.component';
 import {ImportService} from './import/import.service';
 import {AppConfigService} from './app-config.service';
+import { RepoHistoryComponent } from './repo-history/repo-history.component';
+import {RepoHistoryService} from './repo-history/repo-history.service';
+import {CommitHistoryModule} from './commit-history/commit-history.module';
 
 
 @NgModule({
@@ -57,7 +60,8 @@ import {AppConfigService} from './app-config.service';
     NotesModule,
     FormModule,
     SharedModule,
-    AppRoutingModule
+    AppRoutingModule,
+    CommitHistoryModule
   ],
   declarations: [
     AppComponent,
@@ -71,7 +75,8 @@ import {AppConfigService} from './app-config.service';
     LocalChangesComponent,
     FooterComponent,
     YamlComponent,
-    ImportComponent
+    ImportComponent,
+    RepoHistoryComponent
   ],
   entryComponents: [
     DeleteComponent,
@@ -86,7 +91,8 @@ import {AppConfigService} from './app-config.service';
     YamlResolver,
     FooterService,
     ImportService,
-    AppConfigService
+    AppConfigService,
+    RepoHistoryService
   ],
   bootstrap: [AppComponent]
 })

--- a/webapp-mgmt/cas-management-webapp/src/app/commit-history/commit-history.component.css
+++ b/webapp-mgmt/cas-management-webapp/src/app/commit-history/commit-history.component.css
@@ -1,0 +1,20 @@
+.messageWidth {
+  flex: 0 0 100px;
+}
+
+.pathWidth {
+    flex: 1 1 auto;
+}
+
+.committerWidth {
+  flex: 0 0 240px;
+}
+
+.timeWidth {
+  flex: 0 0 240px;
+}
+
+.actionWidth {
+  flex: 0 0 50px;
+}
+

--- a/webapp-mgmt/cas-management-webapp/src/app/commit-history/commit-history.component.html
+++ b/webapp-mgmt/cas-management-webapp/src/app/commit-history/commit-history.component.html
@@ -1,0 +1,108 @@
+<div style="display:flex;margin-bottom:10px;margin-left:25px;margin-right:25px;">
+  <div style="padding-top: 10px;">
+    <mat-icon style="padding-top: 3px;">history</mat-icon>
+    <h4 style="display: inline;position: relative;top: -5px;">
+      <ng-container i18n>
+        History
+      </ng-container>
+    </h4>
+  </div>
+  <div style="flex: 1 1 auto"></div>
+  <div>
+    <app-controls></app-controls>
+  </div>
+</div>
+
+<div style="display: flex; flex-direction: column;margin-right:25px;margin-left:25px;">
+  <mat-table #table [dataSource]="dataSource">
+
+    <ng-container matColumnDef="path">
+      <mat-header-cell *matHeaderCellDef [ngClass]="'pathWidth'">
+        <ng-container i18n>
+          Service
+        </ng-container>
+      </mat-header-cell>
+      <mat-cell *matCellDef="let row" [ngClass]="'pathWidth'">
+        {{ row.path }}
+      </mat-cell>
+    </ng-container>
+
+    <ng-container matColumnDef="message">
+      <mat-header-cell *matHeaderCellDef [ngClass]="'messageWidth'">
+        <ng-container i18n>
+          Change
+        </ng-container>
+      </mat-header-cell>
+      <mat-cell *matCellDef="let row" [ngClass]="'messageWidth'">
+        {{ row.changeType }}
+      </mat-cell>
+    </ng-container>
+
+    <ng-container matColumnDef="committer">
+      <mat-header-cell *matHeaderCellDef [ngClass]="'committerWidth'">
+        <ng-container i18n>
+          Committer
+        </ng-container>
+      </mat-header-cell>
+      <mat-cell *matCellDef="let row" [ngClass]="'committerWidth'">
+        {{ row.committer }}
+      </mat-cell>
+    </ng-container>
+
+    <ng-container matColumnDef="time">
+      <mat-header-cell *matHeaderCellDef [ngClass]="'timeWidth'">
+        <ng-container i18n>
+          Time
+        </ng-container>
+      </mat-header-cell>
+      <mat-cell *matCellDef="let row" [ngClass]="'timeWidth'">
+        {{ row.commitTime }}
+      </mat-cell>
+    </ng-container>
+
+    <ng-container matColumnDef="actions">
+      <mat-header-cell *matHeaderCellDef [ngClass]="'actionWidth'">
+        <ng-container i18n>
+           &nbsp;
+        </ng-container>
+      </mat-header-cell>
+      <mat-cell *matCellDef="let row" [ngClass]="'actionWidth'">
+        <button mat-icon-button [matMenuTriggerFor]="historyMenu" (click)="selectedItem = row">
+          <mat-icon>menu</mat-icon>
+        </button>
+      </mat-cell>
+    </ng-container>
+
+
+    <mat-header-row *matHeaderRowDef="displayedColumns"></mat-header-row>
+    <mat-row *matRowDef="let row; columns: displayedColumns;"></mat-row>
+  </mat-table>
+
+  <mat-paginator #paginator
+                 [pageSize]="10"
+                 [pageSizeOptions]="[5, 10, 25, 100]">
+  </mat-paginator>
+</div>
+
+<mat-menu #historyMenu>
+  <button mat-menu-item (click)="viewChange()">
+    <mat-icon>visibility</mat-icon>
+    <ng-container i18n>View</ng-container>
+  </button>
+  <button mat-menu-item (click)="viewDiff()">
+    <mat-icon>compare_arrows</mat-icon>
+    <ng-container i18n>View Diff</ng-container>
+  </button>
+  <button mat-menu-item (click)="viewJSON()">
+    <mat-icon>code</mat-icon>
+    <ng-container>Json</ng-container>
+  </button>
+  <button mat-menu-item (click)="viewYaml()">
+    <mat-icon>code</mat-icon>
+    <ng-container>Yaml</ng-container>
+  </button>
+  <button mat-menu-item *ngIf="selectedItem && selectedItem.changeType != 'ADD'" (click)="revert()">
+    <mat-icon>undo</mat-icon>
+    <ng-container i18n>checkout</ng-container>
+  </button>
+</mat-menu>

--- a/webapp-mgmt/cas-management-webapp/src/app/commit-history/commit-history.component.spec.ts
+++ b/webapp-mgmt/cas-management-webapp/src/app/commit-history/commit-history.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { CommitHistoryComponent } from './commit-history.component';
+
+describe('CommitHistoryComponent', () => {
+  let component: CommitHistoryComponent;
+  let fixture: ComponentFixture<CommitHistoryComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ CommitHistoryComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(CommitHistoryComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/webapp-mgmt/cas-management-webapp/src/app/commit-history/commit-history.component.ts
+++ b/webapp-mgmt/cas-management-webapp/src/app/commit-history/commit-history.component.ts
@@ -1,0 +1,84 @@
+import {Component, OnInit, ViewChild} from '@angular/core';
+import {Messages} from '../messages';
+import {ActivatedRoute, Router} from '@angular/router';
+import {CommitHistoryService} from './commit-history.service';
+import {History} from '../../domain/history';
+import {Location} from '@angular/common';
+import {ChangesService} from '../changes/changes.service';
+import {MatPaginator, MatSnackBar, MatTableDataSource} from '@angular/material';
+import {DiffEntry} from '../../domain/diff-entry';
+
+@Component({
+  selector: 'app-commit-history',
+  templateUrl: './commit-history.component.html',
+  styleUrls: ['./commit-history.component.css']
+})
+export class CommitHistoryComponent implements OnInit {
+
+  displayedColumns = ['actions', 'path', 'message', 'committer', 'time'];
+  dataSource: MatTableDataSource<DiffEntry>;
+
+  @ViewChild(MatPaginator) paginator: MatPaginator;
+
+  fileName: String;
+
+  selectedItem: DiffEntry;
+
+  constructor(public messages: Messages,
+              private route: ActivatedRoute,
+              private router: Router,
+              private service: CommitHistoryService,
+              private changeService: ChangesService,
+              private location: Location,
+              public  snackBar: MatSnackBar) {
+  }
+
+  ngOnInit() {
+    this.dataSource = new MatTableDataSource([]);
+    this.dataSource.paginator = this.paginator;
+    this.route.data
+      .subscribe((data: { resp: DiffEntry[]}) => {
+        if (!data.resp) {
+          this.snackBar.open(this.messages.management_services_status_listfail, 'dismiss', {
+              duration: 5000
+          });
+        }
+        setTimeout(() => {
+          this.dataSource.data = data.resp;
+        }, 10);
+      });
+    this.route.params.subscribe((params) => this.fileName = params['fileName']);
+  }
+
+  viewChange() {
+    this.router.navigate(['/view', this.selectedItem.oldId]);
+  }
+
+  checkout() {
+    this.service.checkout(this.selectedItem.commit as string, this.selectedItem.path)
+      .then(resp => this.snackBar.open('Service successfully restored from history.', 'dismiss', {
+        duration: 5000
+      }));
+  }
+
+  revert() {
+    this.service.revertRepo(this.selectedItem.oldId as string)
+      .then(resp => this.snackBar.open('Service successfully restored from history.', 'dismiss', {
+        duration: 5000
+      }));
+  }
+
+  viewDiff() {
+    this.router.navigate(['/diff', {oldId: this.selectedItem.oldId, newId: this.selectedItem.newId}]);
+  }
+
+  viewJSON() {
+    this.router.navigate(['/viewJson', this.selectedItem.oldId]);
+  }
+
+  viewYaml() {
+    this.router.navigate(['/viewYaml', this.selectedItem.oldId]);
+  }
+}
+
+

--- a/webapp-mgmt/cas-management-webapp/src/app/commit-history/commit-history.module.ts
+++ b/webapp-mgmt/cas-management-webapp/src/app/commit-history/commit-history.module.ts
@@ -1,0 +1,28 @@
+/**
+ * Created by tschmidt on 2/23/17.
+ */
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { SharedModule } from '../shared/shared.module';
+import {CommitHistoryComponent} from './commit-history.component';
+import {CommitHistoryService} from './commit-history.service';
+import {CommitHistoryResolve} from './commit-history.resolver';
+
+@NgModule({
+  imports: [
+    CommonModule,
+    FormsModule,
+    SharedModule
+  ],
+  declarations: [
+    CommitHistoryComponent,
+  ],
+  providers: [
+    CommitHistoryResolve,
+    CommitHistoryService
+  ]
+})
+
+export class CommitHistoryModule {}
+

--- a/webapp-mgmt/cas-management-webapp/src/app/commit-history/commit-history.resolver.ts
+++ b/webapp-mgmt/cas-management-webapp/src/app/commit-history/commit-history.resolver.ts
@@ -1,0 +1,21 @@
+import {Injectable} from '@angular/core';
+import {Resolve, Router, ActivatedRouteSnapshot} from '@angular/router';
+import { History } from '../../domain/history';
+import {CommitHistoryService} from './commit-history.service';
+import {DiffEntry} from '../../domain/diff-entry';
+
+@Injectable()
+export class CommitHistoryResolve implements Resolve<DiffEntry[]> {
+
+  constructor(private service: CommitHistoryService, private router: Router) {}
+
+  resolve(route: ActivatedRouteSnapshot): Promise<DiffEntry[]> {
+    const param: string = route.params['id'];
+
+    if (!param) {
+      return new Promise((resolve, reject) => resolve([]));
+    } else {
+      return this.service.history(param).then(resp => resp ? resp : null);
+    }
+  }
+}

--- a/webapp-mgmt/cas-management-webapp/src/app/commit-history/commit-history.service.ts
+++ b/webapp-mgmt/cas-management-webapp/src/app/commit-history/commit-history.service.ts
@@ -1,0 +1,29 @@
+/**
+ * Created by tschmidt on 2/13/17.
+ */
+import {Injectable} from '@angular/core';
+import {History} from '../../domain/history';
+import {Service} from '../service';
+import {Http} from '@angular/http';
+import {HttpClient} from '@angular/common/http';
+import {DiffEntry} from '../../domain/diff-entry';
+
+@Injectable()
+export class CommitHistoryService extends Service {
+
+  constructor(protected http: HttpClient) {
+    super(http);
+  }
+
+  history(id: string): Promise<DiffEntry[]> {
+    return this.get<DiffEntry[]>('commitHistoryList?id=' + id);
+  }
+
+  checkout(id: string, path: String): Promise<String> {
+    return this.getText('checkout?id=' + id + '&path=' + path);
+  }
+
+  revertRepo(id: string): Promise<String> {
+    return this.getText('revertRepo?id=' + id);
+  }
+}

--- a/webapp-mgmt/cas-management-webapp/src/app/controls/controls.service.ts
+++ b/webapp-mgmt/cas-management-webapp/src/app/controls/controls.service.ts
@@ -46,7 +46,7 @@ export class ControlsService extends Service {
   }
 
   sync(): Promise<String> {
-    return this.getText("sync");
+    return this.getText('sync');
   }
 
 }

--- a/webapp-mgmt/cas-management-webapp/src/app/header/header.component.html
+++ b/webapp-mgmt/cas-management-webapp/src/app/header/header.component.html
@@ -57,6 +57,10 @@
     <mat-icon>sync</mat-icon>
     <ng-container i18n>Synchronize</ng-container>
   </button>
+  <button *ngIf="isAdmin()" mat-menu-item routerLink="/repo-history">
+    <mat-icon>history</mat-icon>
+    <ng-container i18n>History</ng-container>
+  </button>
   <button mat-menu-item target="_self" id="logoutUrlLink" (click)="logout()">
     <mat-icon>exit_to_app</mat-icon>
     <ng-container i18n="management.services.header.navbar.navitem.logout">

--- a/webapp-mgmt/cas-management-webapp/src/app/header/header.component.ts
+++ b/webapp-mgmt/cas-management-webapp/src/app/header/header.component.ts
@@ -47,7 +47,7 @@ export class HeaderComponent implements OnInit {
 
   sync() {
     this.controlsService.sync().then(resp => {
-      this.snackBar.open("Services Synchronized", "Dismiss", {
+      this.snackBar.open('Services Synchronized', 'Dismiss', {
         duration: 5000
       });
     });

--- a/webapp-mgmt/cas-management-webapp/src/app/repo-history/repo-history.component.css
+++ b/webapp-mgmt/cas-management-webapp/src/app/repo-history/repo-history.component.css
@@ -1,0 +1,15 @@
+.actionWidth {
+    flex: 0 0 50px;
+}
+
+.nameWidth {
+    flex: 0 0 350px;
+}
+
+.messageWidth {
+    flex: 1 1 auto;
+}
+
+.statusWidth {
+    flex: 0 0 200px;
+}

--- a/webapp-mgmt/cas-management-webapp/src/app/repo-history/repo-history.component.html
+++ b/webapp-mgmt/cas-management-webapp/src/app/repo-history/repo-history.component.html
@@ -1,0 +1,87 @@
+<div style="display:flex;margin-bottom:10px;margin-left:25px;margin-right:25px;">
+  <div style="padding-top: 10px;">
+    <mat-icon style="padding-top: 3px;">history</mat-icon>
+    <h4 style="display: inline;position: relative;top: -5px;">
+      <ng-container i18n>
+        History
+      </ng-container>
+    </h4>
+  </div>
+  <div style="flex: 1 1 auto"></div>
+  <div>
+    <app-controls></app-controls>
+  </div>
+</div>
+
+<div style="display: flex; flex-direction: column;margin-right:25px;margin-left:25px;">
+  <mat-table #table [dataSource]="dataSource">
+
+    <ng-container matColumnDef="message">
+      <mat-header-cell *matHeaderCellDef [ngClass]="'messageWidth'">
+        <ng-container i18n>
+          Message
+        </ng-container>
+      </mat-header-cell>
+      <mat-cell *matCellDef="let row" [ngClass]="'messageWidth'">
+        {{ row.text}}
+      </mat-cell>
+    </ng-container>
+
+    <ng-container matColumnDef="id">
+      <mat-header-cell *matHeaderCellDef [ngClass]="'nameWidth'">
+        <ng-container i18n>
+          Id
+        </ng-container>
+      </mat-header-cell>
+      <mat-cell *matCellDef="let row" [ngClass]="'nameWidth'">
+        <a (click)="viewChanges(row)">
+          {{ row.id }}
+        </a>
+      </mat-cell>
+    </ng-container>
+
+    <ng-container matColumnDef="time">
+      <mat-header-cell *matHeaderCellDef [ngClass]="'statusWidth'">
+        <ng-container i18n>
+          Time
+        </ng-container>
+      </mat-header-cell>
+      <mat-cell *matCellDef="let row" [ngClass]="'statusWidth'">
+        {{ row.commitTime }}
+      </mat-cell>
+    </ng-container>
+
+    <ng-container matColumnDef="actions">
+      <mat-header-cell *matHeaderCellDef [ngClass]="'actionWidth'">
+        <ng-container i18n>
+          &nbsp;
+        </ng-container>
+      </mat-header-cell>
+      <mat-cell *matCellDef="let row" [ngClass]="'actionWidth'">
+        <button mat-icon-button [matMenuTriggerFor]="pullMenu" (click)="selectedItem = row">
+          <mat-icon>menu</mat-icon>
+        </button>
+      </mat-cell>
+    </ng-container>
+
+
+    <mat-header-row *matHeaderRowDef="displayedColumns"></mat-header-row>
+    <mat-row *matRowDef="let row; columns: displayedColumns;"></mat-row>
+  </mat-table>
+
+  <mat-paginator #paginator
+                 [pageSize]="10"
+                 [pageSizeOptions]="[5, 10, 25, 100]">
+  </mat-paginator>
+</div>
+
+<mat-menu #pullMenu>
+  <button mat-menu-item (click)="viewChanges()">
+    <mat-icon>visibility</mat-icon>
+    <ng-container i18n>View Changes</ng-container>
+  </button>
+  <button mat-menu-item (click)="checkout()">
+    <mat-icon>restore</mat-icon>
+    <ng-container i18n>Checkout</ng-container>
+  </button>
+</mat-menu>

--- a/webapp-mgmt/cas-management-webapp/src/app/repo-history/repo-history.component.spec.ts
+++ b/webapp-mgmt/cas-management-webapp/src/app/repo-history/repo-history.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { RepoHistoryComponent } from './repo-history.component';
+
+describe('RepoHistoryComponent', () => {
+  let component: RepoHistoryComponent;
+  let fixture: ComponentFixture<RepoHistoryComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ RepoHistoryComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(RepoHistoryComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/webapp-mgmt/cas-management-webapp/src/app/repo-history/repo-history.component.ts
+++ b/webapp-mgmt/cas-management-webapp/src/app/repo-history/repo-history.component.ts
@@ -1,0 +1,48 @@
+import {Component, OnInit, ViewChild} from '@angular/core';
+import {Messages} from '../messages';
+import {RepoHistoryService} from './repo-history.service';
+import {MatPaginator, MatSnackBar, MatTableDataSource} from '@angular/material';
+import {Commit} from '../../domain/commit';
+import {Router} from '@angular/router';
+
+@Component({
+  selector: 'app-repo-history',
+  templateUrl: './repo-history.component.html',
+  styleUrls: ['./repo-history.component.css']
+})
+export class RepoHistoryComponent implements OnInit {
+
+  dataSource: MatTableDataSource<Commit>;
+  displayedColumns = ['actions', 'id', 'message', 'time'];
+  selectedItem: Commit;
+
+  @ViewChild(MatPaginator)
+  paginator: MatPaginator;
+
+  constructor(public messages: Messages,
+              private service: RepoHistoryService,
+              private router: Router,
+              private snackBar: MatSnackBar) { }
+
+  ngOnInit() {
+    this.dataSource = new MatTableDataSource<Commit>([]);
+    this.dataSource.paginator = this.paginator;
+    this.service.commitLogs().then(resp => this.dataSource.data = resp);
+  }
+
+  viewChanges(commit?: Commit) {
+    if (commit) {
+      this.selectedItem = commit;
+    }
+
+    this.router.navigate(['/commit-history', this.selectedItem.id]);
+  }
+
+  checkout() {
+    this.service.checkout(this.selectedItem.id).then(resp => {
+      this.snackBar.open('Commit has been checked out', 'Dismiss', {
+        duration: 5000
+      });
+    })
+  }
+}

--- a/webapp-mgmt/cas-management-webapp/src/app/repo-history/repo-history.service.ts
+++ b/webapp-mgmt/cas-management-webapp/src/app/repo-history/repo-history.service.ts
@@ -1,0 +1,20 @@
+import {Injectable} from '@angular/core';
+import {Service} from '../service';
+import {Commit} from '../../domain/commit';
+import {HttpClient} from '@angular/common/http';
+
+@Injectable()
+export class RepoHistoryService extends Service {
+
+  constructor(http: HttpClient) {
+    super(http);
+  }
+
+  commitLogs(): Promise<Commit[]> {
+    return this.get<Commit[]>('commits');
+  }
+
+  checkout(id: String): Promise<String> {
+    return this.getText('checkoutCommit?id=' + id);
+  }
+}

--- a/webapp-mgmt/cas-management-webapp/src/domain/commit.ts
+++ b/webapp-mgmt/cas-management-webapp/src/domain/commit.ts
@@ -4,9 +4,11 @@
 export class Commit {
   id: String;
   text: String;
+  commitTime: String;
 
-  constructor(id: String, text: String) {
+  constructor(id: String, text: String, commitTime: String) {
     this.id = id;
     this.text = text;
+    this.commitTime = commitTime;
   }
 }

--- a/webapp-mgmt/cas-management-webapp/src/domain/diff-entry.ts
+++ b/webapp-mgmt/cas-management-webapp/src/domain/diff-entry.ts
@@ -7,4 +7,7 @@ export class DiffEntry {
   newId: String;
   diff: String;
   changeType: String;
+  committer: String;
+  commitTime: String;
+  commit: String;
 }


### PR DESCRIPTION
Adds a "History" option for admins under the the main menu.  This is a history of all commits made to the Service Registry.  Second screen shows all changes included in the selected commit.  Admins have the option of checkout an entire commit to restore the registry to a previous state.  They can also cherry pick files from the screen showing all changes for a commit.

Also fixes bug to load AppConfig when browser refreshed.