### PR TITLE
v6.0-Fix MultifactorAuthenticationProviderTypes from discovery.

### DIFF
--- a/webapp-mgmt/cas-management-webapp-support/src/main/java/org/apereo/cas/mgmt/services/web/factory/FormDataFactory.java
+++ b/webapp-mgmt/cas-management-webapp-support/src/main/java/org/apereo/cas/mgmt/services/web/factory/FormDataFactory.java
@@ -107,7 +107,7 @@ public class FormDataFactory {
         if (profile.isPresent() && !profile.get().getMultifactorAuthenticationProviderTypesSupported().isEmpty()) {
             final CasServerProfile p = profile.get();
             final List<FormData.Option> mfas = p.getMultifactorAuthenticationProviderTypesSupported().entrySet().stream()
-                .map(e -> new FormData.Option(e.getKey(), e.getValue()))
+                .map(e -> new FormData.Option(e.getValue(), e.getKey()))
                 .collect(Collectors.toList());
             formData.setMfaProviders(mfas);
         } else {


### PR DESCRIPTION
Arguments should be in reverse order, when creating form options for
mfaProviders from CasServer profile.