### PR TITLE
Update discoveryProfile end point

### DIFF
--- a/core/cas-mgmt-core/src/main/java/org/apereo/cas/mgmt/factory/FormDataFactory.java
+++ b/core/cas-mgmt-core/src/main/java/org/apereo/cas/mgmt/factory/FormDataFactory.java
@@ -62,7 +62,7 @@ public class FormDataFactory {
     @PostConstruct
     private void callForProfile() {
         if (!mgmtProperties.isEnableDiscoveryEndpointCall()) {
-            LOGGER.warn("Call to cas/status/discovery disabled by management configuration.  Using default FormData values.");
+            LOGGER.warn("Call to cas/actuator/discoveryProfile disabled by management configuration.  Using default FormData values.");
             return;
         }
         if (StringUtils.isBlank(casProperties.getServer().getName())) {
@@ -71,7 +71,7 @@ public class FormDataFactory {
         }
 
         val params = new HashMap<String, Object>();
-        val url = casProperties.getServer().getPrefix() + "/status/discovery";
+        val url = casProperties.getServer().getPrefix() + "/actuator/discoveryProfile";
         try {
             val response = HttpUtils.executeGet(url, params);
             if (response != null) {


### PR DESCRIPTION
In CAS 6.x, discovery profile has changed from cas/status/discovery to
cas/actuator/discoveryProfile.