### PR TITLE
Fill drop down menus with values from the xxxTypesSupported elements.

### DIFF
--- a/core/cas-mgmt-core/src/main/java/org/apereo/cas/mgmt/factory/FormDataFactory.java
+++ b/core/cas-mgmt-core/src/main/java/org/apereo/cas/mgmt/factory/FormDataFactory.java
@@ -92,10 +92,10 @@ public class FormDataFactory {
     }
 
     private void loadServiceTypes(final FormData formData) {
-        if (profile.isPresent() && !profile.get().getRegisteredServiceTypes().isEmpty()) {
+        if (profile.isPresent() && !profile.get().getRegisteredServiceTypesSupported().isEmpty()) {
             val p = profile.get();
 
-            val types = p.getRegisteredServiceTypes().entrySet().stream()
+            val types = p.getRegisteredServiceTypesSupported().entrySet().stream()
                 .map(e -> new FormData.Option(e.getKey(), e.getValue().getTypeName()))
                 .collect(Collectors.toList());
             formData.setServiceTypes(types);
@@ -111,9 +111,9 @@ public class FormDataFactory {
     }
 
     private void loadMfaProviders(final FormData formData) {
-        if (profile.isPresent() && !profile.get().getMultifactorAuthenticationProviderTypes().isEmpty()) {
+        if (profile.isPresent() && !profile.get().getMultifactorAuthenticationProviderTypesSupported().isEmpty()) {
             val p = profile.get();
-            val mfas = p.getMultifactorAuthenticationProviderTypes().entrySet().stream()
+            val mfas = p.getMultifactorAuthenticationProviderTypesSupported().entrySet().stream()
                 .map(e -> new FormData.Option(e.getValue(), e.getKey()))
                 .collect(Collectors.toList());
             formData.setMfaProviders(mfas);
@@ -133,9 +133,9 @@ public class FormDataFactory {
     }
 
     private void loadDelegatedClientTypes(final FormData formData) {
-        if (profile.isPresent() && !profile.get().getDelegatedClientTypes().isEmpty()) {
+        if (profile.isPresent() && !profile.get().getDelegatedClientTypesSupported().isEmpty()) {
             val p = profile.get();
-            formData.setDelegatedAuthnProviders(p.getDelegatedClientTypes());
+            formData.setDelegatedAuthnProviders(p.getDelegatedClientTypesSupported());
         } else {
             val delegatedAuthnProviders = new HashSet<String>();
             delegatedAuthnProviders.add("Twitter");


### PR DESCRIPTION
When using discovery end point, values from registeredServiceTypesSupported, multifactorAuthenticationProviderTypesSupported and delegatedClientTypesSupported should be used to fill the drop down menus, as these elements expose what types are supported by CAS.

This PR revert changes in PR#46