### PR TITLE
Added check for null value causing an error when selecting SAML2

### DIFF
--- a/webapp/cas-mgmt-webapp-workspace/libs/domain-lib/src/lib/saml-service.model.ts
+++ b/webapp/cas-mgmt-webapp-workspace/libs/domain-lib/src/lib/saml-service.model.ts
@@ -58,7 +58,7 @@ export class SamlRegisteredService extends RegexRegisteredService {
     super(service);
     const s: SamlRegisteredService = SamlRegisteredService.instanceOf(service) ? service as SamlRegisteredService : undefined;
     this.metadataLocation = s?.metadataLocation;
-    this.metadataMaxValidity = s.metadataMaxValidity;
+    this.metadataMaxValidity = s?.metadataMaxValidity;
     this.requiredAuthenticationContextClass = s?.requiredAuthenticationContextClass;
     this.metadataCriteriaDirection = s?.metadataCriteriaDirection;
     this.metadataCriteriaPattern = s?.metadataCriteriaPattern;


### PR DESCRIPTION
Fixes issue with setting SAML2 as service type when creating a new service. The passed service was undefined, so the null check keeps the statement from throwing an error (and thus not actually setting the type).
