### PR TITLE
use binding for slf4j 1.7

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -470,6 +470,7 @@ subprojects {
         api libraries.commons
         api libraries.springboot
         api libraries.log4j
+        api libraries.slf4j
         api libraries.javax
         
         if (!Boolean.getBoolean("skipErrorProneCompiler")) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -78,6 +78,7 @@ javaxSoapApiVersion=1.4.0
 javaxJwsVersion=3.1.2.2
 javaxJmsVersion=3.1.2.2
 
+slf4jVersion=2.0.0-alpha1
 disruptorVersion=3.4.2
 
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -78,7 +78,6 @@ javaxSoapApiVersion=1.4.0
 javaxJwsVersion=3.1.2.2
 javaxJmsVersion=3.1.2.2
 
-slf4jVersion=2.0.0-alpha1
 disruptorVersion=3.4.2
 
 

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -36,7 +36,11 @@ ext.libraries = [
                     force = true
                 }
         ],
-    
+        slf4j                   : [
+                dependencies.create("org.slf4j:slf4j-api:$slf4jVersion"),
+                dependencies.create("org.slf4j:jul-to-slf4j:$slf4jVersion"),
+                dependencies.create("org.slf4j:jcl-over-slf4j:$slf4jVersion"),
+        ],
         log4j                   : [
                 dependencies.create("org.springframework.boot:spring-boot-starter-log4j2:$springBootVersion") {
                     exclude(group: "org.springframework", module: "spring-web")
@@ -72,7 +76,7 @@ ext.libraries = [
                     exclude(group: "org.slf4j", module: "slf4j-api")
                     force = true
                 },
-                dependencies.create("org.apache.logging.log4j:log4j-slf4j-impl:$log4jVersion") {
+                dependencies.create("org.apache.logging.log4j:log4j-slf4j18-impl:$log4jVersion") {
                     exclude(group: "org.slf4j", module: "slf4j-api")
                     force = true
                 },

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -72,7 +72,7 @@ ext.libraries = [
                     exclude(group: "org.slf4j", module: "slf4j-api")
                     force = true
                 },
-                dependencies.create("org.apache.logging.log4j:log4j-slf4j18-impl:$log4jVersion") {
+                dependencies.create("org.apache.logging.log4j:log4j-slf4j-impl:$log4jVersion") {
                     exclude(group: "org.slf4j", module: "slf4j-api")
                     force = true
                 },


### PR DESCRIPTION
Looks like slfj4 dependencies are currently 1.7 (on 6.3 branch) so this switches to log4j2 binding for 1.7. 