### PR TITLE
force slf4j version to 2.0.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -470,6 +470,7 @@ subprojects {
         api libraries.commons
         api libraries.springboot
         api libraries.log4j
+        api libraries.slf4j
         api libraries.javax
         api libraries.groovy
         api libraries.jackson

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -36,7 +36,7 @@ ext.libraries = [
                     force = true
                 }
         ],
-                jackson                 : [
+        jackson                 : [
                 dependencies.create("com.fasterxml.jackson.core:jackson-databind:$jacksonVersion") {
                     exclude(group: "com.fasterxml.jackson.core", module: "jackson-annotations")
                     exclude(group: "com.fasterxml.jackson.core", module: "jackson-core")
@@ -124,6 +124,17 @@ ext.libraries = [
                     exclude(group: "org.codehaus.groovy", module: "groovy-console")
                     force = true
                 }
+        ],
+        slf4j                   : [
+                dependencies.create("org.slf4j:slf4j-api:$slf4jVersion"){
+                    force = true
+                },
+                dependencies.create("org.slf4j:jul-to-slf4j:$slf4jVersion"){
+                    force = true
+                },
+                dependencies.create("org.slf4j:jcl-over-slf4j:$slf4jVersion"){
+                    force = true
+                },
         ],
         log4j                   : [
                 dependencies.create("org.springframework.boot:spring-boot-starter-log4j2:$springBootVersion") {


### PR DESCRIPTION
This fixed the slf4j (2.0.x) version to match the version used by CAS, although I tested it without the latest groovy/jackson dependency fixes. 
