### PR TITLE
Fixed issue with classnames on tickets tab

### DIFF
--- a/webapp/cas-mgmt-webapp-workspace/libs/mgmt-lib/src/lib/form/proxy-ticket-exp/proxy-ticket-exp.form.ts
+++ b/webapp/cas-mgmt-webapp-workspace/libs/mgmt-lib/src/lib/form/proxy-ticket-exp/proxy-ticket-exp.form.ts
@@ -1,5 +1,9 @@
 import {FormGroup} from '@angular/forms';
-import {RegisteredServiceProxyTicketExpirationPolicy} from 'domain-lib';
+import {
+  proxyTicketExpirationPolicy,
+  RegisteredServiceProxyTicketExpirationPolicy,
+  DefaultRegisteredServiceProxyTicketExpirationPolicy
+} from 'domain-lib';
 import {MgmtFormControl} from '../mgmt-formcontrol';
 
 export class ProxyTicketExpForm extends FormGroup {
@@ -16,9 +20,11 @@ export class ProxyTicketExpForm extends FormGroup {
 
   mapForm(): RegisteredServiceProxyTicketExpirationPolicy {
     if (this.numberOfUses.value || this.timeToLive.value) {
-      const policy = new RegisteredServiceProxyTicketExpirationPolicy();
-      policy.timeToLive = this.timeToLive.value;
-      policy.numberOfUses = this.numberOfUses.value;
+      const policy = proxyTicketExpirationPolicy({
+        timeToLive: this.timeToLive.value,
+        numberOfUses: this.numberOfUses.value,
+        '@class': DefaultRegisteredServiceProxyTicketExpirationPolicy.cName
+      });
       return policy;
     }
     return null;

--- a/webapp/cas-mgmt-webapp-workspace/libs/mgmt-lib/src/lib/form/service-ticket-exp/service-ticket-exp.form.ts
+++ b/webapp/cas-mgmt-webapp-workspace/libs/mgmt-lib/src/lib/form/service-ticket-exp/service-ticket-exp.form.ts
@@ -1,5 +1,5 @@
 import {FormGroup} from '@angular/forms';
-import {RegisteredServiceServiceTicketExpirationPolicy} from 'domain-lib';
+import { serviceTicketExpirationPolicy, RegisteredServiceServiceTicketExpirationPolicy, DefaultRegisteredServiceServiceTicketExpirationPolicy } from 'domain-lib';
 import {MgmtFormControl} from '../mgmt-formcontrol';
 
 export class ServiceTicketExpForm extends FormGroup {
@@ -16,9 +16,11 @@ export class ServiceTicketExpForm extends FormGroup {
 
   mapForm(): RegisteredServiceServiceTicketExpirationPolicy {
     if (this.numberOfUses.value || this.timeToLive.value) {
-      const policy = new RegisteredServiceServiceTicketExpirationPolicy();
-      policy.timeToLive = this.timeToLive.value;
-      policy.numberOfUses = this.numberOfUses.value;
+      const policy = serviceTicketExpirationPolicy({
+        timeToLive: this.timeToLive.value,
+        numberOfUses: this.numberOfUses.value,
+        '@class': DefaultRegisteredServiceServiceTicketExpirationPolicy.cName
+      });
       return policy;
     }
     return null;


### PR DESCRIPTION
This fixes an issue where the classnames submitted from the 'Tickets' tab were referencing a Java interface rather than the Default class name which implements that interface. Updated the form to submit the correct class name.