### PR TITLE
Fixed redirect on landing to hit registry

### DIFF
--- a/webapp/cas-mgmt-webapp-workspace/projects/management/src/app/app-routing.module.ts
+++ b/webapp/cas-mgmt-webapp-workspace/projects/management/src/app/app-routing.module.ts
@@ -30,6 +30,10 @@ const routes: Routes = [
     path: '',
     pathMatch: 'full',
     redirectTo: 'registry'
+  },
+  {
+    path: '**',
+    redirectTo: 'registry'
   }
 ];
 


### PR DESCRIPTION
When landing at /cas-management, there was an error that the route `cas-management` was not defined. This redirects that route to the default, 'registry'.