### PR TITLE
Changing the service name during service edits creates duplicate service config JSON files with the same service ID.

### DIFF
--- a/webapp/cas-mgmt-webapp-config/src/main/java/org/apereo/cas/mgmt/config/CasManagementWebAppConfiguration.java
+++ b/webapp/cas-mgmt-webapp-config/src/main/java/org/apereo/cas/mgmt/config/CasManagementWebAppConfiguration.java
@@ -6,8 +6,6 @@ import org.apereo.cas.mgmt.controller.ViewController;
 import org.apereo.cas.mgmt.web.DefaultCasManagementEventListener;
 import org.apereo.cas.oidc.claims.BaseOidcScopeAttributeReleasePolicy;
 import org.apereo.cas.oidc.claims.OidcCustomScopeAttributeReleasePolicy;
-import org.apereo.cas.services.resource.DefaultRegisteredServiceResourceNamingStrategy;
-import org.apereo.cas.services.resource.RegisteredServiceResourceNamingStrategy;
 import org.apereo.cas.util.CollectionUtils;
 
 import lombok.val;
@@ -132,13 +130,6 @@ public class CasManagementWebAppConfiguration implements WebMvcConfigurer {
     @Bean
     public DefaultCasManagementEventListener defaultCasManagementEventListener() {
         return new DefaultCasManagementEventListener();
-    }
-
-    @Bean(name = "namingStrategy")
-    @RefreshScope
-    public RegisteredServiceResourceNamingStrategy registeredServiceResourceNamingStrategy() {
-        return new DefaultRegisteredServiceResourceNamingStrategy() {
-        };
     }
 
     @Bean

--- a/webapp/cas-mgmt-webapp-config/src/main/java/org/apereo/cas/mgmt/config/CasManagementWebAppConfiguration.java
+++ b/webapp/cas-mgmt-webapp-config/src/main/java/org/apereo/cas/mgmt/config/CasManagementWebAppConfiguration.java
@@ -97,7 +97,7 @@ public class CasManagementWebAppConfiguration implements WebMvcConfigurer {
             protected Locale determineDefaultLocale(final HttpServletRequest request) {
                 val locale = request.getLocale();
                 if (StringUtils.isEmpty(managementProperties.getDefaultLocale())
-                        || !locale.getLanguage().equals(managementProperties.getDefaultLocale())) {
+                    || !locale.getLanguage().equals(managementProperties.getDefaultLocale())) {
                     return locale;
                 }
                 return new Locale(managementProperties.getDefaultLocale());
@@ -123,9 +123,9 @@ public class CasManagementWebAppConfiguration implements WebMvcConfigurer {
     public Collection<BaseOidcScopeAttributeReleasePolicy> userDefinedScopeBasedAttributeReleasePolicies() {
         val oidc = casProperties.getAuthn().getOidc();
         return oidc.getUserDefinedScopes().entrySet()
-                .stream()
-                .map(k -> new OidcCustomScopeAttributeReleasePolicy(k.getKey(), CollectionUtils.wrapList(k.getValue().split(","))))
-                .collect(Collectors.toSet());
+            .stream()
+            .map(k -> new OidcCustomScopeAttributeReleasePolicy(k.getKey(), CollectionUtils.wrapList(k.getValue().split(","))))
+            .collect(Collectors.toSet());
     }
 
     @RefreshScope
@@ -159,7 +159,7 @@ public class CasManagementWebAppConfiguration implements WebMvcConfigurer {
     @Override
     public void addResourceHandlers(final ResourceHandlerRegistry registry) {
         registry.addResourceHandler("/**")
-                .addResourceLocations("classpath:/dist/", "classpath:/static/");
+            .addResourceLocations("classpath:/dist/", "classpath:/static/");
     }
 
     @Bean

--- a/webapp/cas-mgmt-webapp-config/src/main/java/org/apereo/cas/mgmt/config/CasManagementWebAppConfiguration.java
+++ b/webapp/cas-mgmt-webapp-config/src/main/java/org/apereo/cas/mgmt/config/CasManagementWebAppConfiguration.java
@@ -6,7 +6,7 @@ import org.apereo.cas.mgmt.controller.ViewController;
 import org.apereo.cas.mgmt.web.DefaultCasManagementEventListener;
 import org.apereo.cas.oidc.claims.BaseOidcScopeAttributeReleasePolicy;
 import org.apereo.cas.oidc.claims.OidcCustomScopeAttributeReleasePolicy;
-import org.apereo.cas.services.RegisteredService;
+import org.apereo.cas.services.resource.DefaultRegisteredServiceResourceNamingStrategy;
 import org.apereo.cas.services.resource.RegisteredServiceResourceNamingStrategy;
 import org.apereo.cas.util.CollectionUtils;
 
@@ -97,7 +97,7 @@ public class CasManagementWebAppConfiguration implements WebMvcConfigurer {
             protected Locale determineDefaultLocale(final HttpServletRequest request) {
                 val locale = request.getLocale();
                 if (StringUtils.isEmpty(managementProperties.getDefaultLocale())
-                    || !locale.getLanguage().equals(managementProperties.getDefaultLocale())) {
+                        || !locale.getLanguage().equals(managementProperties.getDefaultLocale())) {
                     return locale;
                 }
                 return new Locale(managementProperties.getDefaultLocale());
@@ -123,9 +123,9 @@ public class CasManagementWebAppConfiguration implements WebMvcConfigurer {
     public Collection<BaseOidcScopeAttributeReleasePolicy> userDefinedScopeBasedAttributeReleasePolicies() {
         val oidc = casProperties.getAuthn().getOidc();
         return oidc.getUserDefinedScopes().entrySet()
-            .stream()
-            .map(k -> new OidcCustomScopeAttributeReleasePolicy(k.getKey(), CollectionUtils.wrapList(k.getValue().split(","))))
-            .collect(Collectors.toSet());
+                .stream()
+                .map(k -> new OidcCustomScopeAttributeReleasePolicy(k.getKey(), CollectionUtils.wrapList(k.getValue().split(","))))
+                .collect(Collectors.toSet());
     }
 
     @RefreshScope
@@ -137,11 +137,7 @@ public class CasManagementWebAppConfiguration implements WebMvcConfigurer {
     @Bean(name = "namingStrategy")
     @RefreshScope
     public RegisteredServiceResourceNamingStrategy registeredServiceResourceNamingStrategy() {
-        return new RegisteredServiceResourceNamingStrategy() {
-            @Override
-            public String build(final RegisteredService service, final String extenstion) {
-                return service.getName() + "-" + service.getId() + ".json";
-            }
+        return new DefaultRegisteredServiceResourceNamingStrategy() {
         };
     }
 
@@ -163,7 +159,7 @@ public class CasManagementWebAppConfiguration implements WebMvcConfigurer {
     @Override
     public void addResourceHandlers(final ResourceHandlerRegistry registry) {
         registry.addResourceHandler("/**")
-            .addResourceLocations("classpath:/dist/", "classpath:/static/");
+                .addResourceLocations("classpath:/dist/", "classpath:/static/");
     }
 
     @Bean

--- a/webapp/cas-mgmt-webapp-config/src/main/java/org/apereo/cas/mgmt/config/CasManagementWebAppConfiguration.java
+++ b/webapp/cas-mgmt-webapp-config/src/main/java/org/apereo/cas/mgmt/config/CasManagementWebAppConfiguration.java
@@ -140,7 +140,7 @@ public class CasManagementWebAppConfiguration implements WebMvcConfigurer {
         return new RegisteredServiceResourceNamingStrategy() {
             @Override
             public String build(final RegisteredService service, final String extenstion) {
-                return "service-" + service.getId() + ".json";
+                return service.getName() + "-" + service.getId() + ".json";
             }
         };
     }


### PR DESCRIPTION
- Brief description of changes applied:

Changing the service name during service edits creates duplicate service config JSON files with the same service ID.
Dashboard pulls the old config records. The check for service rename is failing during service update. Fixed a bug in the default RegisteredServiceResourceNamingStrategy that gets wired in to the manager.

- Any documentation on how to configure, test:

Open CasMgmt Dashboard. Create a new CAS service. Requery the service just created. Edit the service name and other config data related to the service and save. Requery this service again. The config changes should now display changes accurately. 

- Any possible limitations, side effects, etc

No

- Reference any other pull requests that might be related:

N/A