### PR TITLE
Load available attributes from profile

### DIFF
--- a/core/cas-mgmt-core/src/main/java/org/apereo/cas/mgmt/factory/FormDataFactory.java
+++ b/core/cas-mgmt-core/src/main/java/org/apereo/cas/mgmt/factory/FormDataFactory.java
@@ -151,18 +151,17 @@ public class FormDataFactory {
     }
 
     private void loadAvailableAttributes(final FormData formData) {
+        val attributes = attributeDefinitionStore.getAttributeDefinitions().stream()
+            .map(AttributeDefinition::getKey)
+            .collect(toSet());
+        val props = casProperties.getAuthn().getAttributeRepository();
+        val stub = (NamedStubPersonAttributeDao) Beans.newStubAttributeRepository(props);
+        attributes.addAll(stub.getBackingMap().keySet());
         if (profile.isPresent() && !profile.get().getAvailableAttributes().isEmpty()) {
             val p = profile.get();
-            formData.setAvailableAttributes(p.getAvailableAttributes());
-        } else {
-            val attributes = attributeDefinitionStore.getAttributeDefinitions().stream()
-                .map(AttributeDefinition::getKey)
-                .collect(toSet());
-            val props = casProperties.getAuthn().getAttributeRepository();
-            val stub = (NamedStubPersonAttributeDao) Beans.newStubAttributeRepository(props);
-            attributes.addAll(stub.getBackingMap().keySet());
-            formData.setAvailableAttributes(attributes);
+            attributes.addAll(p.getAvailableAttributes());
         }
+        formData.setAvailableAttributes(attributes);
     }
 
     private void loadAttributeRepositories(final FormData formData) {

--- a/core/cas-mgmt-core/src/main/java/org/apereo/cas/mgmt/factory/FormDataFactory.java
+++ b/core/cas-mgmt-core/src/main/java/org/apereo/cas/mgmt/factory/FormDataFactory.java
@@ -151,13 +151,18 @@ public class FormDataFactory {
     }
 
     private void loadAvailableAttributes(final FormData formData) {
-        val attributes = attributeDefinitionStore.getAttributeDefinitions().stream()
-            .map(AttributeDefinition::getKey)
-            .collect(toSet());
-        val props = casProperties.getAuthn().getAttributeRepository();
-        val stub = (NamedStubPersonAttributeDao) Beans.newStubAttributeRepository(props);
-        attributes.addAll(stub.getBackingMap().keySet());
-        formData.setAvailableAttributes(attributes);
+        if (profile.isPresent() && !profile.get().getAvailableAttributes().isEmpty()) {
+            val p = profile.get();
+            formData.setAvailableAttributes(p.getAvailableAttributes());
+        } else {
+            val attributes = attributeDefinitionStore.getAttributeDefinitions().stream()
+                .map(AttributeDefinition::getKey)
+                .collect(toSet());
+            val props = casProperties.getAuthn().getAttributeRepository();
+            val stub = (NamedStubPersonAttributeDao) Beans.newStubAttributeRepository(props);
+            attributes.addAll(stub.getBackingMap().keySet());
+            formData.setAvailableAttributes(attributes);
+        }
     }
 
     private void loadAttributeRepositories(final FormData formData) {


### PR DESCRIPTION



Hello to everyone,

I noticed that in the Attribute Release Policy section of the services ui, when the user chooses RETURN ALLOWED, no attribute was available for him/her to check, even though attributes were present in discovery endpoint/profile.

 After a short examination, I ended up with a small code modification in loadAvailableAttributes method of the FormDataFactory class, for the purpose of loading the attributes from the user profile when it is present.    
