### PR TITLE
Use a list instead of set in order to sort the available attributes

### DIFF
--- a/api/cas-mgmt-api-core/src/main/java/org/apereo/cas/mgmt/domain/FormData.java
+++ b/api/cas-mgmt-api-core/src/main/java/org/apereo/cas/mgmt/domain/FormData.java
@@ -45,7 +45,7 @@ import java.util.stream.Stream;
 public class FormData implements Serializable {
     private static final long serialVersionUID = -5201796557461644152L;
 
-    private Set<String> availableAttributes = new HashSet<>();
+    private List<String> availableAttributes = new ArrayList<>();
 
     private Set<String> attributeRepositories = new HashSet<>();
 

--- a/core/cas-mgmt-core/src/main/java/org/apereo/cas/mgmt/factory/FormDataFactory.java
+++ b/core/cas-mgmt-core/src/main/java/org/apereo/cas/mgmt/factory/FormDataFactory.java
@@ -161,7 +161,7 @@ public class FormDataFactory {
             val p = profile.get();
             attributes.addAll(p.getAvailableAttributes());
         }
-        formData.setAvailableAttributes(attributes);
+        formData.setAvailableAttributes(attributes.stream().sorted().collect(toList()));
     }
 
     private void loadAttributeRepositories(final FormData formData) {


### PR DESCRIPTION
Hello,

In the attribute release policy section, the available attributes are unsorted.

To remedy this, a list has been used instead of a set.