### PR TITLE
Bugfix/consent policy

### DIFF
--- a/webapp/cas-mgmt-webapp-workspace/projects/mgmt-lib/src/lib/field/attribute-release/attribute-release.module.ts
+++ b/webapp/cas-mgmt-webapp-workspace/projects/mgmt-lib/src/lib/field/attribute-release/attribute-release.module.ts
@@ -21,6 +21,8 @@ import {UiModule} from '@apereo/mgmt-lib/src/lib/ui';
 import {MatExpansionModule} from '@angular/material/expansion';
 import {MatMenuModule} from '@angular/material/menu';
 import {MatRadioModule} from '@angular/material/radio';
+import { MatIconModule } from '@angular/material/icon';
+import { MatTooltipModule } from '@angular/material/tooltip';
 
 /**
  * Module to lazy-load Attribute Release functionality.
@@ -37,7 +39,9 @@ import {MatRadioModule} from '@angular/material/radio';
     WsfedattrrelpoliciesModule,
     MatExpansionModule,
     MatMenuModule,
-    MatRadioModule
+    MatRadioModule,
+    MatIconModule,
+    MatTooltipModule
   ],
   declarations: [
     ChecksComponent,

--- a/webapp/cas-mgmt-webapp-workspace/projects/mgmt-lib/src/lib/field/attribute-release/consent/consent.component.html
+++ b/webapp/cas-mgmt-webapp-workspace/projects/mgmt-lib/src/lib/field/attribute-release/consent/consent.component.html
@@ -1,14 +1,38 @@
-<lib-checkbox [control]="form.consentEnabled" label="User Consent Enabled"
-              toolTip="Control whether consent is active/inactive for this service.">
-</lib-checkbox>
+<div>
+  <label id="consent-enabled">
+    User Consent Enabled
+    <mat-icon class="icon" i18n-matTooltip libHelp
+      matTooltip="Control whether consent is active/inactive for this service."></mat-icon>
+  </label>
+</div>
+<br />
 
-<ng-container *ngIf="form.consentEnabled.value">
+<mat-radio-group [formControl]="form.consentEnabled" aria-labelledby="consent-enabled">
+
+  <mat-radio-button [value]="STATUS_OPTIONS.TRUE" style="margin-right: 1em;">
+    <ng-container i18n>True</ng-container>
+    <mat-icon class="icon" style="margin-left: 0.25em;" libHelp i18n-matTooltip matTooltip="Consent policy is disabled, overriding the global configuration."></mat-icon>
+  </mat-radio-button>
+
+  <mat-radio-button [value]="STATUS_OPTIONS.FALSE" style="margin-right: 1em;">
+    <ng-container i18n>False</ng-container>
+    <mat-icon class="icon" style="margin-left: 0.25em;" libHelp i18n-matTooltip matTooltip="Consent policy is enabled, overriding the global configuration."></mat-icon>
+  </mat-radio-button>
+
+  <mat-radio-button [value]="STATUS_OPTIONS.UNDEFINED">
+    <ng-container i18n>Undefined</ng-container>
+    <mat-icon class="icon" style="margin-left: 0.25em;" libHelp i18n-matTooltip matTooltip="Consent policy is undefined, delegating the decision to the global configuration."></mat-icon>
+  </mat-radio-button>
+
+</mat-radio-group>
+
+<ng-container *ngIf="form.consentEnabled.value === STATUS_OPTIONS.TRUE">
   <lib-select-input [control]="form.excluded" label="Excluded Attributes" [options]="config.options.availableAttributes" multiple
                     toolTip="Exclude the indicated attributes from consent.">
   </lib-select-input>
 </ng-container>
 
-<ng-container *ngIf="form.consentEnabled.value">
+<ng-container *ngIf="form.consentEnabled.value === STATUS_OPTIONS.TRUE">
   <lib-select-input [control]="form.includeOnly" label="Include Only Attributes" [options]="config.options.availableAttributes" multiple
                     toolTip="Force-include the indicated attributes in consent, provided attributes are resolved.">
   </lib-select-input>

--- a/webapp/cas-mgmt-webapp-workspace/projects/mgmt-lib/src/lib/field/attribute-release/consent/consent.component.ts
+++ b/webapp/cas-mgmt-webapp-workspace/projects/mgmt-lib/src/lib/field/attribute-release/consent/consent.component.ts
@@ -1,4 +1,5 @@
 import {Component, Input} from '@angular/core';
+import { ConsentStatus } from '@apereo/mgmt-lib/src/lib/model';
 import {ConsentForm} from '@apereo/mgmt-lib/src/lib/form';
 import {AppConfigService} from '@apereo/mgmt-lib/src/lib/ui';
 
@@ -18,6 +19,8 @@ export class ConsentComponent {
 
   @Input()
   attributes: string[];
+
+  STATUS_OPTIONS = ConsentStatus;
 
   constructor(public config: AppConfigService) {
   }

--- a/webapp/cas-mgmt-webapp-workspace/projects/mgmt-lib/src/lib/form/attribute-release/consent.form.ts
+++ b/webapp/cas-mgmt-webapp-workspace/projects/mgmt-lib/src/lib/form/attribute-release/consent.form.ts
@@ -1,5 +1,5 @@
 import {FormControl, FormGroup} from '@angular/forms';
-import {RegisteredServiceConsentPolicy} from '@apereo/mgmt-lib/src/lib/model';
+import {ConsentStatus, RegisteredServiceConsentPolicy} from '@apereo/mgmt-lib/src/lib/model';
 
 /**
  * Form group to display and update fields for Consent.
@@ -8,13 +8,13 @@ import {RegisteredServiceConsentPolicy} from '@apereo/mgmt-lib/src/lib/model';
  */
 export class ConsentForm extends FormGroup {
 
-  get consentEnabled() { return this.get('enabled') as FormControl; }
+  get consentEnabled() { return this.get('status') as FormControl; }
   get excluded() { return this.get('excludedAttributes') as FormControl; }
   get includeOnly() { return this.get('includeOnlyAttributes') as FormControl; }
 
   constructor(policy: RegisteredServiceConsentPolicy) {
     super({
-      enabled: new FormControl(policy?.enabled),
+      status: new FormControl(policy?.status),
       excludedAttributes: new FormControl(policy?.excludedAttributes),
       includeOnlyAttributes: new FormControl(policy?.includeOnlyAttributes)
     });
@@ -26,7 +26,7 @@ export class ConsentForm extends FormGroup {
    * @param policy - RegisteredServiceConsentPolicy
    */
   map(policy: RegisteredServiceConsentPolicy) {
-    policy.enabled = this.consentEnabled.value;
+    policy.status = this.consentEnabled.value;
     policy.excludedAttributes = this.excluded.value;
     policy.includeOnlyAttributes = this.includeOnly.value;
   }

--- a/webapp/cas-mgmt-webapp-workspace/projects/mgmt-lib/src/lib/model/service-model/consent-policy.model.ts
+++ b/webapp/cas-mgmt-webapp-workspace/projects/mgmt-lib/src/lib/model/service-model/consent-policy.model.ts
@@ -1,10 +1,17 @@
+export enum ConsentStatus {
+  TRUE = 'TRUE',
+  FALSE = 'FALSE',
+  UNDEFINED = 'UNDEFINED'
+}
+
 /**
  * Data class for RegisteredServiceConsentPolicy.
  */
+
 export class RegisteredServiceConsentPolicy {
   static cName = 'org.apereo.cas.services.RegisteredServiceConsentPolicy';
 
-  enabled: boolean;
+  status: ConsentStatus;
   excludedAttributes: string[];
   includeOnlyAttributes: string[];
 
@@ -18,7 +25,7 @@ export class RegisteredServiceConsentPolicy {
   }
 
   constructor(policy?: RegisteredServiceConsentPolicy) {
-    this.enabled = policy?.enabled ?? true;
+    this.status = policy?.status || ConsentStatus.UNDEFINED;
     this.excludedAttributes = policy?.excludedAttributes;
     this.includeOnlyAttributes = policy?.includeOnlyAttributes;
     this['@class'] = RegisteredServiceConsentPolicy.cName;


### PR DESCRIPTION
This change allows cas-management to support the `status` property on attribute release consent policies, switching from the older `enabled` boolean property. 

https://apereo.github.io/cas/6.3.x/integration/Attribute-Release-Consent.html
