### PR TITLE
Fixed issue with tokens in oauth services

### DIFF
--- a/webapp/cas-mgmt-webapp-workspace/projects/mgmt-lib/src/lib/form/token-expiration/access-token-expiration.form.ts
+++ b/webapp/cas-mgmt-webapp-workspace/projects/mgmt-lib/src/lib/form/token-expiration/access-token-expiration.form.ts
@@ -1,5 +1,5 @@
 import {FormControl, FormGroup} from '@angular/forms';
-import {RegisteredServiceOAuthAccessTokenExpirationPolicy} from '@apereo/mgmt-lib/src/lib/model';
+import { RegisteredServiceOAuthAccessTokenExpirationPolicy, accessTokenExpirationPolicy} from '@apereo/mgmt-lib/src/lib/model';
 
 /**
  * Form group for displaying and updating Access Token Expiration policy.
@@ -23,7 +23,7 @@ export class AccessTokenExpirationForm extends FormGroup {
    */
   map(): RegisteredServiceOAuthAccessTokenExpirationPolicy {
     if (this.maxTimeToLive.value) {
-      const policy = new RegisteredServiceOAuthAccessTokenExpirationPolicy();
+      const policy = accessTokenExpirationPolicy();
       policy.timeToKill = this.timeToKill.value;
       policy.maxTimeToLive = this.maxTimeToLive.value;
       return policy;

--- a/webapp/cas-mgmt-webapp-workspace/projects/mgmt-lib/src/lib/form/token-expiration/code-expiration.form.ts
+++ b/webapp/cas-mgmt-webapp-workspace/projects/mgmt-lib/src/lib/form/token-expiration/code-expiration.form.ts
@@ -1,5 +1,5 @@
 import {FormControl, FormGroup} from '@angular/forms';
-import {RegisteredServiceOAuthCodeExpirationPolicy} from '@apereo/mgmt-lib/src/lib/model';
+import { codeExpirationPolicy, RegisteredServiceOAuthCodeExpirationPolicy } from '@apereo/mgmt-lib/src/lib/model';
 
 /**
  * Form group for displaying and updating Access Code Expiration policy.
@@ -23,7 +23,7 @@ export class CodeExpirationForm extends FormGroup {
    */
   map(): RegisteredServiceOAuthCodeExpirationPolicy {
     if (this.numberOfUses.value) {
-      const policy = new RegisteredServiceOAuthCodeExpirationPolicy();
+      const policy = codeExpirationPolicy();
       policy.numberOfUses = this.numberOfUses.value;
       policy.timeToLive = this.timeToLive.value;
       return policy;

--- a/webapp/cas-mgmt-webapp-workspace/projects/mgmt-lib/src/lib/form/token-expiration/device-token-expiration.form.ts
+++ b/webapp/cas-mgmt-webapp-workspace/projects/mgmt-lib/src/lib/form/token-expiration/device-token-expiration.form.ts
@@ -1,5 +1,5 @@
 import {FormControl, FormGroup} from '@angular/forms';
-import {RegisteredServiceOAuthDeviceTokenExpirationPolicy} from '@apereo/mgmt-lib/src/lib/model';
+import { RegisteredServiceOAuthDeviceTokenExpirationPolicy, deviceTokenExpirationPolicy} from '@apereo/mgmt-lib/src/lib/model';
 
 /**
  * Form group for displaying and updating Device Token Expiration policy.
@@ -21,7 +21,7 @@ export class DeviceTokenExpirationForm extends FormGroup {
    */
   map(): RegisteredServiceOAuthDeviceTokenExpirationPolicy {
     if (this.timeToKill.value) {
-      const policy = new RegisteredServiceOAuthDeviceTokenExpirationPolicy();
+      const policy = deviceTokenExpirationPolicy();
       policy.timeToKill = this.timeToKill.value;
       return policy;
     }

--- a/webapp/cas-mgmt-webapp-workspace/projects/mgmt-lib/src/lib/form/token-expiration/refresh-token-expiration.form.ts
+++ b/webapp/cas-mgmt-webapp-workspace/projects/mgmt-lib/src/lib/form/token-expiration/refresh-token-expiration.form.ts
@@ -1,5 +1,5 @@
 import {FormControl, FormGroup} from '@angular/forms';
-import {RegisteredServiceOAuthRefreshTokenExpirationPolicy} from '@apereo/mgmt-lib/src/lib/model';
+import { RegisteredServiceOAuthRefreshTokenExpirationPolicy, refreshTokenExpirationPolicy } from '@apereo/mgmt-lib/src/lib/model';
 
 /**
  * Form group for displaying and updating Refresh Token Expiration policy.
@@ -21,7 +21,7 @@ export class RefreshTokenExpirationForm extends FormGroup {
    */
   map(): RegisteredServiceOAuthRefreshTokenExpirationPolicy {
     if (this.timeToKill.value) {
-      const policy = new RegisteredServiceOAuthRefreshTokenExpirationPolicy();
+      const policy = refreshTokenExpirationPolicy();
       policy.timeToKill = this.timeToKill.value;
       return policy;
     }


### PR DESCRIPTION
This fixes an issue where completing the token tab for an OAuth service (any of the 4 sections) resulted in a 500 error from the server. This was due to the wrong class being sent. This fixes the class name of each section.