### PR TITLE
Fixed tickets tab on oauth services

### DIFF
--- a/webapp/cas-mgmt-webapp-workspace/projects/mgmt-lib/src/lib/form/proxy-ticket-exp.form.ts
+++ b/webapp/cas-mgmt-webapp-workspace/projects/mgmt-lib/src/lib/form/proxy-ticket-exp.form.ts
@@ -1,5 +1,5 @@
 import {FormControl, FormGroup} from '@angular/forms';
-import {RegisteredServiceProxyTicketExpirationPolicy} from '@apereo/mgmt-lib/src/lib/model';
+import { RegisteredServiceProxyTicketExpirationPolicy, proxyTicketExpirationPolicy} from '@apereo/mgmt-lib/src/lib/model';
 
 /**
  * Form group for displaying and updating Proxy Ticket Expiration policies.
@@ -23,7 +23,7 @@ export class ProxyTicketExpForm extends FormGroup {
    */
   map(): RegisteredServiceProxyTicketExpirationPolicy {
     if (this.numberOfUses.value || this.timeToLive.value) {
-      const policy = new RegisteredServiceProxyTicketExpirationPolicy();
+      const policy = proxyTicketExpirationPolicy();
       policy.timeToLive = this.timeToLive.value;
       policy.numberOfUses = this.numberOfUses.value;
       return policy;

--- a/webapp/cas-mgmt-webapp-workspace/projects/mgmt-lib/src/lib/form/service-ticket-exp.form.ts
+++ b/webapp/cas-mgmt-webapp-workspace/projects/mgmt-lib/src/lib/form/service-ticket-exp.form.ts
@@ -1,5 +1,5 @@
 import {FormControl, FormGroup} from '@angular/forms';
-import {RegisteredServiceServiceTicketExpirationPolicy} from '@apereo/mgmt-lib/src/lib/model';
+import {RegisteredServiceServiceTicketExpirationPolicy, serviceTicketExpirationPolicy} from '@apereo/mgmt-lib/src/lib/model';
 
 /**
  * Form group for displaying and updating Service Ticket Expiration policy.
@@ -23,7 +23,7 @@ export class ServiceTicketExpForm extends FormGroup {
    */
   map(): RegisteredServiceServiceTicketExpirationPolicy {
     if (this.numberOfUses.value || this.timeToLive.value) {
-      const policy = new RegisteredServiceServiceTicketExpirationPolicy();
+      const policy = serviceTicketExpirationPolicy();
       policy.timeToLive = this.timeToLive.value;
       policy.numberOfUses = this.numberOfUses.value;
       return policy;


### PR DESCRIPTION
This fixes an issue where completing the tickets tab for an OAuth service (any of the sections) resulted in a 500 error from the server. This was due to the wrong class being sent. This fixes the class name of each section.