### PR TITLE
Fixed Oauth response type form

### DIFF
--- a/webapp/cas-mgmt-webapp-workspace/projects/mgmt-lib/src/lib/form/oauth/oauthclient.form.ts
+++ b/webapp/cas-mgmt-webapp-workspace/projects/mgmt-lib/src/lib/form/oauth/oauthclient.form.ts
@@ -24,7 +24,7 @@ export class OauthClientForm extends FormGroup implements MgmtFormGroup<OAuthReg
       clientSecret: new FormControl(service?.clientSecret, Validators.required),
       bypassApprovalPrompt: new FormControl(service?.bypassApprovalPrompt),
       generateRefreshToken: new FormControl(service?.generateRefreshToken),
-      responseTypes: new FormControl(service?.responseType),
+      responseTypes: new FormControl(service?.supportedResponseTypes),
       grantTypes: new FormControl(service?.supportedGrantTypes),
       jwtAccessToken: new FormControl(service?.jwtAccessToken),
       showClient: new FormControl(false)


### PR DESCRIPTION
This fixes an issue where the response type field on the client tab was not populated with the values saved on a service.