### PR TITLE
Fixed error with authn policies tab

### DIFF
--- a/webapp/cas-mgmt-webapp-workspace/projects/mgmt-lib/src/lib/field/authn-policy/authn-policy.component.html
+++ b/webapp/cas-mgmt-webapp-workspace/projects/mgmt-lib/src/lib/field/authn-policy/authn-policy.component.html
@@ -13,7 +13,6 @@
                [matChipInputFor]="requiredChipList"
                matChipInputAddOnBlur="true"
                [matChipInputSeparatorKeyCodes]="separatorKeysCodes"
-               [matAutocomplete]="autoRequiredHandler"
                (matChipInputTokenEnd)="addRequiredHandler($event)"
                #requiredHandlerInput>
       </mat-form-field>
@@ -30,9 +29,9 @@
       </mat-chip-list>
     </div>
 
-<!--    <mat-autocomplete #autoRequiredHandler="matAutocomplete" (optionSelected)="selectionRequiredHandler($event);">-->
-<!--      <mat-option *ngFor="let h of requiredAuthenticationHandlers" [value]="h">{{ h }}</mat-option>-->
-<!--    </mat-autocomplete>-->
+    <!--<mat-autocomplete #autoRequiredHandler="matAutocomplete" (optionSelected)="selectionRequiredHandler($event);">
+      <mat-option *ngFor="let h of requiredAuthenticationHandlers" [value]="h">{{ h }}</mat-option>
+    </mat-autocomplete>-->
   </div>
 
 
@@ -47,7 +46,6 @@
                [matChipInputFor]="excludedChipList"
                matChipInputAddOnBlur="true"
                [matChipInputSeparatorKeyCodes]="separatorKeysCodes"
-               [matAutocomplete]="autoExcludedHandler"
                (matChipInputTokenEnd)="addExcludedHandler($event)"
                #excludedHandlerInput>
       </mat-form-field>
@@ -64,9 +62,9 @@
       </mat-chip-list>
     </div>
 
-<!--    <mat-autocomplete #autoExcludedHandler="matAutocomplete" (optionSelected)="selectionExcludedHandler($event);">-->
-<!--      <mat-option *ngFor="let h of excludedAuthenticationHandlers" [value]="h">{{ h }}</mat-option>-->
-<!--    </mat-autocomplete>-->
+  <!--<mat-autocomplete #autoExcludedHandler="matAutocomplete" (optionSelected)="selectionExcludedHandler($event);">
+      <mat-option *ngFor="let h of excludedAuthenticationHandlers" [value]="h">{{ h }}</mat-option>
+  </mat-autocomplete>-->
 
 
   </div>

--- a/webapp/cas-mgmt-webapp-workspace/projects/mgmt-lib/src/lib/field/authn-policy/authn-policy.component.ts
+++ b/webapp/cas-mgmt-webapp-workspace/projects/mgmt-lib/src/lib/field/authn-policy/authn-policy.component.ts
@@ -1,17 +1,17 @@
-import {Component, ElementRef, Input, ViewChild} from '@angular/core';
+import {Component, ElementRef, Input, OnChanges, SimpleChanges, ViewChild} from '@angular/core';
 import {AuthenticationPolicyForm, FormService} from "@apereo/mgmt-lib/src/lib/form";
 import {COMMA, ENTER} from "@angular/cdk/keycodes";
 import {MatAutocompleteSelectedEvent, MatAutocompleteTrigger} from "@angular/material/autocomplete";
 import {MatChipInputEvent} from "@angular/material/chips";
 import {AppConfigService} from '@apereo/mgmt-lib/src/lib/ui';
-import {CriteriaType} from '@apereo/mgmt-lib/src/lib/model';
+import {CriteriaType, RegisteredServiceAuthenticationPolicy} from '@apereo/mgmt-lib/src/lib/model';
 
 @Component({
   selector: 'lib-authn-policy',
   templateUrl: './authn-policy.component.html',
   styleUrls: ['./authn-policy.component.css']
 })
-export class AuthenticationPolicyComponent {
+export class AuthenticationPolicyComponent implements OnChanges {
 
   type: CriteriaType;
   TYPE = CriteriaType;
@@ -40,14 +40,24 @@ export class AuthenticationPolicyComponent {
   form: AuthenticationPolicyForm;
 
   constructor(public config: AppConfigService, private service: FormService) {
-    let policy = service?.registeredService?.authenticationPolicy;
+    this.reset(this.service?.registeredService?.authenticationPolicy);
+  }
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes.form) {
+      this.reset(this.form.value);
+    }
+  }
+
+  reset(policy: RegisteredServiceAuthenticationPolicy): void {
+    this.requiredAuthenticationHandlers = [];
+    this.excludedAuthenticationHandlers = [];
     policy?.requiredAuthenticationHandlers?.forEach(h => {
       this.requiredAuthenticationHandlers.push(h);
     });
     policy?.excludedAuthenticationHandlers?.forEach(h => {
       this.excludedAuthenticationHandlers.push(h);
     });
-
   }
 
   addRequiredHandler(event: MatChipInputEvent): void {
@@ -57,9 +67,9 @@ export class AuthenticationPolicyComponent {
     if ((value || '').trim()) {
       this.requiredAuthenticationHandlers.push(value.trim());
       //this.autoRequiredTrigger.closePanel();
-      this.form.requiredAuthenticationHandlers.setValue(this.requiredAuthenticationHandlers);
       this.form.requiredAuthenticationHandlers.markAsTouched();
       this.form.requiredAuthenticationHandlers.markAsDirty();
+      this.form.requiredAuthenticationHandlers.setValue(this.requiredAuthenticationHandlers);
     }
 
     if (input) {
@@ -75,9 +85,9 @@ export class AuthenticationPolicyComponent {
     if ((value || '').trim()) {
       this.excludedAuthenticationHandlers.push(value.trim());
       //this.autoExcludedTrigger.closePanel();
-      this.form.excludedAuthenticationHandlers.setValue(this.excludedAuthenticationHandlers);
       this.form.excludedAuthenticationHandlers.markAsTouched();
       this.form.excludedAuthenticationHandlers.markAsDirty();
+      this.form.excludedAuthenticationHandlers.setValue(this.excludedAuthenticationHandlers);
     }
 
     if (input) {
@@ -90,9 +100,9 @@ export class AuthenticationPolicyComponent {
 
     if (index >= 0) {
       this.requiredAuthenticationHandlers.splice(index, 1);
-      this.form.requiredAuthenticationHandlers.setValue(this.requiredAuthenticationHandlers);
       this.form.requiredAuthenticationHandlers.markAsTouched();
       this.form.requiredAuthenticationHandlers.markAsDirty();
+      this.form.requiredAuthenticationHandlers.setValue(this.requiredAuthenticationHandlers);
     }
   }
 
@@ -101,9 +111,9 @@ export class AuthenticationPolicyComponent {
 
     if (index >= 0) {
       this.excludedAuthenticationHandlers.splice(index, 1);
-      this.form.excludedAuthenticationHandlers.setValue(this.excludedAuthenticationHandlers);
       this.form.excludedAuthenticationHandlers.markAsTouched();
       this.form.excludedAuthenticationHandlers.markAsDirty();
+      this.form.excludedAuthenticationHandlers.setValue(this.excludedAuthenticationHandlers);
     }
   }
 
@@ -111,9 +121,9 @@ export class AuthenticationPolicyComponent {
     const value =  val.option.value;
     if ((value || '').trim()) {
       this.requiredAuthenticationHandlers.push(value.trim());
-      this.form.requiredAuthenticationHandlers.setValue(this.requiredAuthenticationHandlers);
       this.form.requiredAuthenticationHandlers.markAsTouched();
       this.form.requiredAuthenticationHandlers.markAsDirty();
+      this.form.requiredAuthenticationHandlers.setValue(this.requiredAuthenticationHandlers);
     }
 
     if (this.requiredHandlerInput) {
@@ -125,9 +135,9 @@ export class AuthenticationPolicyComponent {
     const value =  val.option.value;
     if ((value || '').trim()) {
       this.excludedAuthenticationHandlers.push(value.trim());
-      this.form.excludedAuthenticationHandlers.setValue(this.requiredAuthenticationHandlers);
       this.form.excludedAuthenticationHandlers.markAsTouched();
       this.form.excludedAuthenticationHandlers.markAsDirty();
+      this.form.excludedAuthenticationHandlers.setValue(this.requiredAuthenticationHandlers);
     }
 
     if (this.excludedHandlerInput) {

--- a/webapp/cas-mgmt-webapp-workspace/projects/mgmt-lib/src/lib/field/authn-policy/authn-policy.component.ts
+++ b/webapp/cas-mgmt-webapp-workspace/projects/mgmt-lib/src/lib/field/authn-policy/authn-policy.component.ts
@@ -24,14 +24,14 @@ export class AuthenticationPolicyComponent {
   requiredAuthenticationHandlers: string[] = [];
   excludedAuthenticationHandlers: string[] = [];
 
-  @ViewChild('autoRequiredHandler', { static: true })
-  autoRequiredTrigger: MatAutocompleteTrigger;
+  /*@ViewChild('autoRequiredHandler', { static: true })
+  autoRequiredTrigger: MatAutocompleteTrigger;*/
 
   @ViewChild('requiredHandlerInput', { static: true })
   requiredHandlerInput: ElementRef;
 
-  @ViewChild('autoExcludedHandler', { static: true })
-  autoExcludedTrigger: MatAutocompleteTrigger;
+  /*@ViewChild('autoExcludedHandler', { static: true })
+  autoExcludedTrigger: MatAutocompleteTrigger;*/
 
   @ViewChild('excludedHandlerInput', { static: true })
   excludedHandlerInput: ElementRef;

--- a/webapp/cas-mgmt-webapp-workspace/projects/mgmt-lib/src/lib/form/data.model.ts
+++ b/webapp/cas-mgmt-webapp-workspace/projects/mgmt-lib/src/lib/form/data.model.ts
@@ -18,6 +18,7 @@ export class ServiceForm extends FormGroup implements MgmtFormGroup<AbstractRegi
 
   constructor(private service: AbstractRegisteredService) {
     super({});
+    // this.valueChanges.subscribe(v => this.map());
   }
 
   /**


### PR DESCRIPTION
Fixes an error when entering values into authn-policy > allowed/excluded authn handlers was causing a javascript error to be thrown. This also fixes an issue where a user could fill out the allowed/excluded field, switch to another tab, and then back to authn, and their changes would have been discarded.