### PR TITLE
Fix for Delegated Authentication in Access Strategy

### DIFF
--- a/webapp/cas-mgmt-webapp-workspace/projects/management/src/app/form/form.component.ts
+++ b/webapp/cas-mgmt-webapp-workspace/projects/management/src/app/form/form.component.ts
@@ -116,7 +116,6 @@ export class FormComponent implements OnInit, OnDestroy, OnChanges {
    * @param id - assigned id of the service returned from the server.
    */
   handleSave(id: number) {
-    console.log('handleSave', id);
     const hasIdAssignedAlready = this.service.registeredService.id && this.service.registeredService.id > 0;
 
     if (!hasIdAssignedAlready && id && id !== -1) {

--- a/webapp/cas-mgmt-webapp-workspace/projects/management/src/app/form/form.component.ts
+++ b/webapp/cas-mgmt-webapp-workspace/projects/management/src/app/form/form.component.ts
@@ -2,7 +2,7 @@ import {Component, OnChanges, OnDestroy, OnInit, SimpleChanges, ViewChild} from 
 import {ActivatedRoute, Router} from '@angular/router';
 import {Location} from '@angular/common';
 import {Observable, Subscription} from 'rxjs';
-import {finalize, map} from 'rxjs/operators';
+import {map} from 'rxjs/operators';
 import {BreakpointObserver} from '@angular/cdk/layout';
 import {
   FormService,
@@ -14,7 +14,6 @@ import {
   ImportService, ControlsService, ServiceForm, SubmissionsService
 } from '@apereo/mgmt-lib';
 import {FormArray, FormGroup} from '@angular/forms';
-import {childRoutes, FormRoutingModule} from './form-routing.module';
 
 /**
  * Component to display/update a service.
@@ -96,6 +95,7 @@ export class FormComponent implements OnInit, OnDestroy, OnChanges {
    */
   ngOnChanges(changes: SimpleChanges) {
     this.controls.showEdit = this.showEdit();
+    console.log('changes', this.controls.showEdit);
   }
 
   /**
@@ -153,7 +153,8 @@ export class FormComponent implements OnInit, OnDestroy, OnChanges {
   loadService(service: AbstractRegisteredService) {
     this.service.registeredService = service;
     this.service.form = new ServiceForm(service);
-    this.service.form.statusChanges.subscribe(() => {
+    this.service.form.statusChanges.subscribe((s) => {
+      console.log('form status changes', s);
       this.controls.showEdit = this.showEdit();
     });
     this.setNav();
@@ -302,6 +303,7 @@ export class FormComponent implements OnInit, OnDestroy, OnChanges {
    * Returns true if the user changed any value in the form.
    */
   dirty(): boolean {
+    console.log('dirty', this.service.form.dirty);
     if (this.service.form.dirty) {
       return true;
     }

--- a/webapp/cas-mgmt-webapp-workspace/projects/management/src/app/form/form.component.ts
+++ b/webapp/cas-mgmt-webapp-workspace/projects/management/src/app/form/form.component.ts
@@ -95,7 +95,6 @@ export class FormComponent implements OnInit, OnDestroy, OnChanges {
    */
   ngOnChanges(changes: SimpleChanges) {
     this.controls.showEdit = this.showEdit();
-    console.log('changes', this.controls.showEdit);
   }
 
   /**
@@ -117,6 +116,7 @@ export class FormComponent implements OnInit, OnDestroy, OnChanges {
    * @param id - assigned id of the service returned from the server.
    */
   handleSave(id: number) {
+    console.log('handleSave', id);
     const hasIdAssignedAlready = this.service.registeredService.id && this.service.registeredService.id > 0;
 
     if (!hasIdAssignedAlready && id && id !== -1) {
@@ -154,7 +154,6 @@ export class FormComponent implements OnInit, OnDestroy, OnChanges {
     this.service.registeredService = service;
     this.service.form = new ServiceForm(service);
     this.service.form.statusChanges.subscribe((s) => {
-      console.log('form status changes', s);
       this.controls.showEdit = this.showEdit();
     });
     this.setNav();
@@ -204,7 +203,7 @@ export class FormComponent implements OnInit, OnDestroy, OnChanges {
       this.tabList.push(['attrRelease', 'Attribute Release']);
     }
     this.tabList.push(['accessstrategy', 'Access Strategy']);
-    this.tabList.push(['delegated', 'Delegated Authentication']);
+    // this.tabList.push(['delegated', 'Delegated Authentication']);
     this.tabList.push(['sso', 'SSO Policy']);
     this.tabList.push(['authnPolicy', 'Authentication Policy']);
     this.tabList.push(['acceptableUsagePolicy', 'Acceptable Usage Policy']);
@@ -303,7 +302,6 @@ export class FormComponent implements OnInit, OnDestroy, OnChanges {
    * Returns true if the user changed any value in the form.
    */
   dirty(): boolean {
-    console.log('dirty', this.service.form.dirty);
     if (this.service.form.dirty) {
       return true;
     }

--- a/webapp/cas-mgmt-webapp-workspace/projects/mgmt-lib/src/lib/field/delegated/delegated.component.ts
+++ b/webapp/cas-mgmt-webapp-workspace/projects/mgmt-lib/src/lib/field/delegated/delegated.component.ts
@@ -50,9 +50,9 @@ export class DelegatedComponent {
     if ((value || '').trim()) {
       this.delegatedAuthn.push(value.trim());
       this.autoTrigger.closePanel();
-      this.form.allowedProviders.setValue(this.delegatedAuthn);
       this.form.allowedProviders.markAsTouched();
       this.form.allowedProviders.markAsDirty();
+      this.form.allowedProviders.setValue(this.delegatedAuthn);
     }
 
     if (input) {
@@ -70,9 +70,9 @@ export class DelegatedComponent {
 
     if (index >= 0) {
       this.delegatedAuthn.splice(index, 1);
-      this.form.allowedProviders.setValue(this.delegatedAuthn);
       this.form.allowedProviders.markAsTouched();
       this.form.allowedProviders.markAsDirty();
+      this.form.allowedProviders.setValue(this.delegatedAuthn);
     }
   }
 
@@ -85,9 +85,9 @@ export class DelegatedComponent {
     const value =  val.option.value;
     if ((value || '').trim()) {
       this.delegatedAuthn.push(value.trim());
-      this.form.allowedProviders.setValue(this.delegatedAuthn);
       this.form.allowedProviders.markAsTouched();
       this.form.allowedProviders.markAsDirty();
+      this.form.allowedProviders.setValue(this.delegatedAuthn);
     }
 
     if (this.providerInput) {

--- a/webapp/cas-mgmt-webapp-workspace/projects/mgmt-lib/src/lib/field/delegated/delegated.component.ts
+++ b/webapp/cas-mgmt-webapp-workspace/projects/mgmt-lib/src/lib/field/delegated/delegated.component.ts
@@ -1,9 +1,10 @@
-import {Component, ElementRef, Input, ViewChild} from '@angular/core';
+import {Component, ElementRef, Input, SimpleChanges, ViewChild} from '@angular/core';
 import {COMMA, ENTER} from '@angular/cdk/keycodes';
 import { MatAutocompleteSelectedEvent, MatAutocompleteTrigger } from '@angular/material/autocomplete';
 import { MatChipInputEvent } from '@angular/material/chips';
 import {DelegatedForm, FormService} from '@apereo/mgmt-lib/src/lib/form';
 import {AppConfigService} from '@apereo/mgmt-lib/src/lib/ui';
+import { RegisteredServiceDelegatedAuthenticationPolicy } from '@apereo/mgmt-lib/src/lib/model';
 
 /**
  * Component for displaying allowed delegated authenticators.
@@ -32,7 +33,18 @@ export class DelegatedComponent {
   providers: string[];
 
   constructor(public config: AppConfigService, private service: FormService) {
-    let policy = service?.registeredService?.accessStrategy?.delegatedAuthenticationPolicy;
+    this.reset(this.service?.registeredService?.accessStrategy?.delegatedAuthenticationPolicy);
+  }
+
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes.form) {
+      this.reset(this.form.value);
+    }
+  }
+
+  reset(policy: RegisteredServiceDelegatedAuthenticationPolicy): void {
+    this.delegatedAuthn = [];
     policy?.allowedProviders?.forEach(provider => {
       this.delegatedAuthn.push(provider);
     });

--- a/webapp/cas-mgmt-webapp-workspace/projects/mgmt-lib/src/lib/form/access-strategy/access-strategy.form.ts
+++ b/webapp/cas-mgmt-webapp-workspace/projects/mgmt-lib/src/lib/form/access-strategy/access-strategy.form.ts
@@ -2,6 +2,7 @@ import {FormControl, FormGroup} from '@angular/forms';
 import {PrincipalRepoType, RegisteredServiceAccessStrategy} from '@apereo/mgmt-lib/src/lib/model';
 import {AttributesForm} from '../attributes.form';
 import {PrincipalRepoForm} from '../attribute-release/principal-repo.form';
+import { DelegatedForm } from '../delegated.form';
 
 /**
  * Form group for displaying and updating access strategy policies.
@@ -17,6 +18,7 @@ export class AccessStrategyForm extends FormGroup {
   get caseInsensitive() { return this.get('caseInsensitive') as FormControl; }
   get rejectedAttributes() { return this.get('rejectedAttributes') as AttributesForm; }
   get principalRepo() { return this.get('repo') as PrincipalRepoForm; }
+  get delegatedAuthenticationPolicy() { return this.get('delegatedAuthenticationPolicy') as DelegatedForm; }
 
   constructor(strategy: RegisteredServiceAccessStrategy) {
     super({
@@ -25,7 +27,8 @@ export class AccessStrategyForm extends FormGroup {
       requiredAttributes: new AttributesForm(strategy?.requiredAttributes),
       caseInsensitive: new FormControl(strategy?.caseInsensitive),
       rejectedAttributes: new AttributesForm(strategy?.rejectedAttributes),
-      repo: new PrincipalRepoForm(strategy?.principalAttributesRepository)
+      repo: new PrincipalRepoForm(strategy?.principalAttributesRepository),
+      delegatedAuthenticationPolicy: new DelegatedForm(strategy?.delegatedAuthenticationPolicy)
     });
     this.principalRepoType = new FormControl(PrincipalRepoType.DEFAULT);
   }
@@ -41,5 +44,6 @@ export class AccessStrategyForm extends FormGroup {
     strategy.requiredAttributes = this.requiredAttributes.map();
     strategy.caseInsensitive = this.caseInsensitive.value;
     strategy.rejectedAttributes = this.rejectedAttributes.map();
+    strategy.delegatedAuthenticationPolicy = this.delegatedAuthenticationPolicy.map();
   }
 }

--- a/webapp/cas-mgmt-webapp-workspace/projects/mgmt-lib/src/lib/form/data.model.ts
+++ b/webapp/cas-mgmt-webapp-workspace/projects/mgmt-lib/src/lib/form/data.model.ts
@@ -18,6 +18,7 @@ export class ServiceForm extends FormGroup implements MgmtFormGroup<AbstractRegi
 
   constructor(private service: AbstractRegisteredService) {
     super({});
+    this.valueChanges.subscribe(v => this.map());
   }
 
   /**

--- a/webapp/cas-mgmt-webapp-workspace/projects/mgmt-lib/src/lib/form/delegated.form.ts
+++ b/webapp/cas-mgmt-webapp-workspace/projects/mgmt-lib/src/lib/form/delegated.form.ts
@@ -1,5 +1,5 @@
 import {FormControl, FormGroup} from '@angular/forms';
-import {RegisteredServiceDelegatedAuthenticationPolicy} from '@apereo/mgmt-lib/src/lib/model';
+import {delegatedAuthenticationPolicyFactory, RegisteredServiceDelegatedAuthenticationPolicy} from '@apereo/mgmt-lib/src/lib/model';
 
 /**
  * Form group for displaying and updating delegated authentication policies.
@@ -25,10 +25,11 @@ export class DelegatedForm extends FormGroup {
    *
    * @param policy - RegisteredServiceDelegatedAuthenticationPolicy
    */
-  map(policy: RegisteredServiceDelegatedAuthenticationPolicy) {
+  map(policy: RegisteredServiceDelegatedAuthenticationPolicy = delegatedAuthenticationPolicyFactory({}) as RegisteredServiceDelegatedAuthenticationPolicy): RegisteredServiceDelegatedAuthenticationPolicy {
     policy.allowedProviders = this.allowedProviders.value;
     policy.permitUndefined = this.permitUndefined.value;
     policy.exclusive = this.exclusive.value;
+    return policy;
   }
 
 }

--- a/webapp/cas-mgmt-webapp-workspace/projects/mgmt-lib/src/lib/model/service-model/access-strategy.model.ts
+++ b/webapp/cas-mgmt-webapp-workspace/projects/mgmt-lib/src/lib/model/service-model/access-strategy.model.ts
@@ -1,4 +1,4 @@
-import {RegisteredServiceDelegatedAuthenticationPolicy} from './delegated-authn.model';
+import { RegisteredServiceDelegatedAuthenticationPolicy, delegatedAuthenticationPolicyFactory } from './delegated-authn.model';
 import {attributeRepoFactory, PrincipalAttributesRepository} from './attribute-repo.model';
 
 /**
@@ -20,7 +20,7 @@ export abstract class RegisteredServiceAccessStrategy {
     this.enabled = strat?.enabled ?? true;
     this.ssoEnabled = strat?.ssoEnabled ?? true;
     this.unauthorizedRedirectUrl = strat?.unauthorizedRedirectUrl;
-    this.delegatedAuthenticationPolicy = strat?.delegatedAuthenticationPolicy;
+    this.delegatedAuthenticationPolicy = delegatedAuthenticationPolicyFactory(strat?.delegatedAuthenticationPolicy);
     this.requiredAttributes = strat?.requiredAttributes;
     this.requireAllAttributes = strat?.requireAllAttributes ?? true;
     this.rejectedAttributes = strat?.rejectedAttributes;

--- a/webapp/cas-mgmt-webapp-workspace/projects/mgmt-lib/src/lib/model/service-model/delegated-authn.model.ts
+++ b/webapp/cas-mgmt-webapp-workspace/projects/mgmt-lib/src/lib/model/service-model/delegated-authn.model.ts
@@ -33,3 +33,7 @@ export class DefaultRegisteredServiceDelegatedAuthenticationPolicy extends Regis
       this['@class'] = DefaultRegisteredServiceDelegatedAuthenticationPolicy.cName;
     }
 }
+
+export function delegatedAuthenticationPolicyFactory (policy: any): RegisteredServiceDelegatedAuthenticationPolicy {
+  return new DefaultRegisteredServiceDelegatedAuthenticationPolicy(policy);
+}

--- a/webapp/cas-mgmt-webapp-workspace/projects/mgmt-lib/src/lib/tab/tab-accessstrategy/tab-accessstrategy.component.html
+++ b/webapp/cas-mgmt-webapp-workspace/projects/mgmt-lib/src/lib/tab/tab-accessstrategy/tab-accessstrategy.component.html
@@ -2,6 +2,10 @@
   <lib-card heading="Service Access Strategy" *ngIf="!groovyAccessStrategy">
     <lib-access-strategy [form]="tab.strategy" [type]="tab.type"></lib-access-strategy>
   </lib-card>
+  <lib-card heading="Delegated Authentication">
+    <lib-delegated [form]="tab.strategy.delegatedAuthenticationPolicy">
+    </lib-delegated>
+  </lib-card>
 
   <lib-card heading="Required Attributes" *ngIf="!groovyAccessStrategy">
     <lib-required [form]="tab.strategy"></lib-required>


### PR DESCRIPTION
This change moves the Delegated Authentication form into the Access Strategy tab, since the delegatedAuthenticationPolicy object is a child of the accessStrategy object. This fixes an issue where any time the user went to the accessStrategy tab, the app would instantiate an accessStrategy without the data from the delegatedAuthenticationPolicy, effectively wiping out whatever the user had previously entered. Since the Delegated Authentication tab only had a small form, it seemed the simplest answer to combine the tabs.