### PR TITLE
Fixed logo link path

### DIFF
--- a/webapp/cas-mgmt-webapp-workspace/projects/mgmt-lib/src/lib/ui/navigation/navigation.component.html
+++ b/webapp/cas-mgmt-webapp-workspace/projects/mgmt-lib/src/lib/ui/navigation/navigation.component.html
@@ -8,7 +8,7 @@
     [mode]="(isHandset$ | async) ? 'over' : 'side'"
     [opened]="(isHandset$ | async) === false">
     <mat-toolbar color="primary">
-      <a class="brand" href="index.html" target="_self" id="homepageUrlLink">
+      <a class="brand" [routerLink]="['/']" target="_self" id="homepageUrlLink">
         <img src="../images/logo_cas.png" alt="CAS" />
       </a>
     </mat-toolbar>


### PR DESCRIPTION
This change fixes the link of the sidebar CAS logo to go to the root of the application.