### PR TITLE
Fixed saving WSFed services

### DIFF
--- a/webapp/cas-mgmt-webapp-workspace/projects/mgmt-lib/src/lib/field/service-id/service-id.component.ts
+++ b/webapp/cas-mgmt-webapp-workspace/projects/mgmt-lib/src/lib/field/service-id/service-id.component.ts
@@ -1,7 +1,7 @@
 import {Component, Input, OnInit} from '@angular/core';
 import {
   SamlRegisteredService,
-  WSFederationRegisterdService,
+  WSFederationRegisteredService,
   OAuthRegisteredService,
   OidcRegisteredService
 } from '@apereo/mgmt-lib/src/lib/model';
@@ -52,7 +52,7 @@ export class ServiceIdComponent implements OnInit {
     } else if (OidcRegisteredService.cName === type ||
       OAuthRegisteredService.cName === type) {
       this.prompt =  'Redirect URL';
-    } else if (WSFederationRegisterdService.cName === type) {
+    } else if (WSFederationRegisteredService.cName === type) {
       this.prompt = 'Consumer URL';
     } else {
       this.prompt = 'Service URL';
@@ -67,10 +67,9 @@ export class ServiceIdComponent implements OnInit {
   tooltip(type: string) {
     if (SamlRegisteredService.cName === type) {
       this.tip = 'An string that represents the EntityId of the SAML2 SP. This can be a regex pattern.';
-    } else if (OidcRegisteredService.cName === type ||
-      OAuthRegisteredService.cName === type) {
+    } else if (OidcRegisteredService.cName === type || OAuthRegisteredService.cName === type) {
       this.tip = 'A url that represents the OAuth/OIDC server to redirect to.';
-    } else if (WSFederationRegisterdService.cName === type) {
+    } else if (WSFederationRegisteredService.cName === type) {
       this.tip = 'A url that represents a WS Federation Consumer URL';
     } else {
       this.tip = 'A url that represents the application. This can be a regex/ant formatted url.';

--- a/webapp/cas-mgmt-webapp-workspace/projects/mgmt-lib/src/lib/form/data.model.ts
+++ b/webapp/cas-mgmt-webapp-workspace/projects/mgmt-lib/src/lib/form/data.model.ts
@@ -2,7 +2,7 @@ import {
   AbstractRegisteredService,
   OAuthRegisteredService, OidcRegisteredService,
   RegexRegisteredService,
-  SamlRegisteredService, WSFederationRegisterdService
+  SamlRegisteredService, WSFederationRegisteredService
 } from '@apereo/mgmt-lib/src/lib/model';
 import {MgmtFormGroup} from './mgmt-form-group';
 import {FormGroup} from '@angular/forms';
@@ -60,6 +60,9 @@ export class ServiceForm extends FormGroup implements MgmtFormGroup<AbstractRegi
   providedIn: 'root'
 })
 export class FormService extends Service {
+
+  private service: AbstractRegisteredService;
+
   typeChange = new EventEmitter<void>();
   registeredService: AbstractRegisteredService;
   form: ServiceForm;
@@ -88,8 +91,8 @@ export class FormService extends Service {
           if (OidcRegisteredService.instanceOf(resp)) {
             return new OidcRegisteredService(resp);
           }
-          if (WSFederationRegisterdService.instanceOf(resp)) {
-            return new WSFederationRegisterdService(resp);
+          if (WSFederationRegisteredService.instanceOf(resp)) {
+            return new WSFederationRegisteredService(resp);
           }
         }),
         catchError(e => this.handleError(e, this.dialog))

--- a/webapp/cas-mgmt-webapp-workspace/projects/mgmt-lib/src/lib/form/data.model.ts
+++ b/webapp/cas-mgmt-webapp-workspace/projects/mgmt-lib/src/lib/form/data.model.ts
@@ -15,8 +15,18 @@ import {catchError, map, take} from 'rxjs/operators';
  * Service Form.
  */
 export class ServiceForm extends FormGroup implements MgmtFormGroup<AbstractRegisteredService> {
+  // private _service: AbstractRegisteredService;
 
-  constructor(private service: AbstractRegisteredService) {
+  get service(): AbstractRegisteredService {
+    return this._service;
+  };
+
+  set service(s: AbstractRegisteredService) {
+    this._service = s;
+    // this.form = new ServiceForm(s);
+  };
+
+  constructor(private _service: AbstractRegisteredService) {
     super({});
   }
 
@@ -62,12 +72,31 @@ export class ServiceForm extends FormGroup implements MgmtFormGroup<AbstractRegi
 export class FormService extends Service {
 
   private service: AbstractRegisteredService;
+  private serviceForm: ServiceForm;
 
   typeChange = new EventEmitter<void>();
-  registeredService: AbstractRegisteredService;
-  form: ServiceForm;
 
   controller = 'api/services/';
+
+
+  get registeredService() : AbstractRegisteredService {
+    return this.service;
+  };
+
+  set registeredService (s: AbstractRegisteredService) {
+    this.service = s;
+    if (this.serviceForm) {
+      this.serviceForm.service = s;
+    }
+  };
+
+  get form(): ServiceForm {
+    return this.serviceForm;
+  }
+
+  set form (s: ServiceForm) {
+    this.serviceForm = s;
+  }
 
   /**
    * Calls the server to get the service for the passed id.

--- a/webapp/cas-mgmt-webapp-workspace/projects/mgmt-lib/src/lib/form/wsfedclient.form.ts
+++ b/webapp/cas-mgmt-webapp-workspace/projects/mgmt-lib/src/lib/form/wsfedclient.form.ts
@@ -1,5 +1,5 @@
 import {FormControl, FormGroup} from '@angular/forms';
-import {WSFederationRegisterdService} from '@apereo/mgmt-lib/src/lib/model';
+import {WSFederationRegisteredService} from '@apereo/mgmt-lib/src/lib/model';
 
 /**
  * Form group for displaying and updating WS Federation client options.
@@ -11,7 +11,7 @@ export class WsfedclientForm extends FormGroup {
   get realm() { return this.get('realm') as FormControl; }
   get appliesTo() { return this.get('appliesTo') as FormControl; }
 
-  constructor(service: WSFederationRegisterdService) {
+  constructor(service: WSFederationRegisteredService) {
     super({
       realm: new FormControl(service?.realm),
       appliesTo: new FormControl(service?.appliesTo)
@@ -21,9 +21,9 @@ export class WsfedclientForm extends FormGroup {
   /**
    * Maps the form values to the passed DTO.
    *
-   * @param service - WSFederationRegisterdService
+   * @param service - WSFederationRegisteredService
    */
-  map(service: WSFederationRegisterdService) {
+  map(service: WSFederationRegisteredService) {
     service.realm = this.realm.value;
     service.appliesTo = this.appliesTo.value;
   }

--- a/webapp/cas-mgmt-webapp-workspace/projects/mgmt-lib/src/lib/model/service-model/attribute-release.ts
+++ b/webapp/cas-mgmt-webapp-workspace/projects/mgmt-lib/src/lib/model/service-model/attribute-release.ts
@@ -271,7 +271,7 @@ export class SamlIdpRegisteredServiceAttributeReleasePolicy extends ReturnMapped
  * Data class for WsFederationClaimsReleasePolicy.
  */
 export class WsFederationClaimsReleasePolicy extends AbstractRegisteredServiceAttributeReleasePolicy {
-  static cName = 'org.apereo.cas.ws.idp.services.WsFederationClaimsReleasePolicy';
+  static cName = 'org.apereo.cas.ws.idp.services.CustomNamespaceWSFederationClaimsReleasePolicy';
 
   allowedAttributes: Map<string, string>;
 

--- a/webapp/cas-mgmt-webapp-workspace/projects/mgmt-lib/src/lib/model/service-model/wsfed-service.model.ts
+++ b/webapp/cas-mgmt-webapp-workspace/projects/mgmt-lib/src/lib/model/service-model/wsfed-service.model.ts
@@ -2,10 +2,10 @@ import {RegexRegisteredService, RegisteredService} from './registered-service.mo
 import {WsFederationClaimsReleasePolicy} from './attribute-release';
 
 /**
- * Data class for WSFederationRegisterdService.
+ * Data class for WSFederationRegisteredService.
  */
-export class WSFederationRegisterdService extends RegexRegisteredService {
-  static readonly cName = 'org.apereo.cas.ws.idp.services.WSFederationRegisteredService';
+export class WSFederationRegisteredService extends RegexRegisteredService {
+  static cName = 'org.apereo.cas.ws.idp.services.WSFederationRegisteredService';
 
   realm: string;
   protocol: string;
@@ -19,18 +19,18 @@ export class WSFederationRegisterdService extends RegexRegisteredService {
   appliesTo: string;
 
   /**
-   * Returns true if the passed object is an instance of WSFederationRegisterdService.
+   * Returns true if the passed object is an instance of WSFederationRegisteredService.
    *
    * @param obj - object to be inspected
    */
   static instanceOf(obj: any): boolean {
-    return obj && obj['@class'] === WSFederationRegisterdService.cName;
+    return obj && obj['@class'] === WSFederationRegisteredService.cName;
   }
 
   constructor(service?: RegisteredService) {
     super(service);
-    const s: WSFederationRegisterdService = WSFederationRegisterdService.instanceOf(service)
-      ? service as WSFederationRegisterdService : undefined;
+    const s: WSFederationRegisteredService = WSFederationRegisteredService.instanceOf(service)
+      ? service as WSFederationRegisteredService : undefined;
     this.realm = s?.realm;
     this.protocol = s?.protocol;
     this.tokenType = s?.tokenType;
@@ -44,6 +44,7 @@ export class WSFederationRegisterdService extends RegexRegisteredService {
     this.attributeReleasePolicy = s?.attributeReleasePolicy && WsFederationClaimsReleasePolicy.instanceOf(s.attributeReleasePolicy)
       ? s.attributeReleasePolicy
       : new WsFederationClaimsReleasePolicy();
-    this['@class'] = WSFederationRegisterdService.cName;
+
+    this['@class'] = WSFederationRegisteredService.cName;
   }
 }

--- a/webapp/cas-mgmt-webapp-workspace/projects/mgmt-lib/src/lib/tab/tab-basics/tab-basics.component.ts
+++ b/webapp/cas-mgmt-webapp-workspace/projects/mgmt-lib/src/lib/tab/tab-basics/tab-basics.component.ts
@@ -4,7 +4,7 @@ import {
   OAuthRegisteredService,
   OidcRegisteredService,
   SamlRegisteredService,
-  WSFederationRegisterdService,
+  WSFederationRegisteredService,
   RegexRegisteredService
 } from '@apereo/mgmt-lib/src/lib/model';
 import {TabBasicsForm} from './tab-basics.form';
@@ -35,8 +35,8 @@ export class TabBasicsComponent {
           service.registeredService = new OidcRegisteredService(service.registeredService);
         } else if (val === SamlRegisteredService.cName) {
           service.registeredService = new SamlRegisteredService(service.registeredService);
-        } else if (val === WSFederationRegisterdService.cName) {
-          service.registeredService = new WSFederationRegisterdService(service.registeredService);
+        } else if (val === WSFederationRegisteredService.cName) {
+          service.registeredService = new WSFederationRegisteredService(service.registeredService);
         } else {
           service.registeredService = new RegexRegisteredService(service.registeredService);
         }

--- a/webapp/cas-mgmt-webapp-workspace/projects/mgmt-lib/src/lib/tab/tab-wsfed-attrrelease/tab-wsfed-attrrelease.form.ts
+++ b/webapp/cas-mgmt-webapp-workspace/projects/mgmt-lib/src/lib/tab/tab-wsfed-attrrelease/tab-wsfed-attrrelease.form.ts
@@ -20,7 +20,7 @@ export class TabWsFedReleaseForm extends FormGroup implements MgmtFormGroup<Abst
   /**
    * Creates or resets controls in the form.
    */
-  rest(): void {
+  reset(): void {
     this.attributes = new AttributesForm(this.policy.allowedAttributes);
   }
 

--- a/webapp/cas-mgmt-webapp-workspace/projects/mgmt-lib/src/lib/tab/tab-wsfed/tab-wsfed.component.ts
+++ b/webapp/cas-mgmt-webapp-workspace/projects/mgmt-lib/src/lib/tab/tab-wsfed/tab-wsfed.component.ts
@@ -1,7 +1,7 @@
 import {Component} from '@angular/core';
 import {FormService} from '@apereo/mgmt-lib/src/lib/form';
 import {TabWsfedForm} from './tab-wsfed.form';
-import {WSFederationRegisterdService} from '@apereo/mgmt-lib/src/lib/model';
+import {WSFederationRegisteredService} from '@apereo/mgmt-lib/src/lib/model';
 
 /**
  * Component to display/update WS Fed options for a service.
@@ -24,7 +24,7 @@ export class TabWsfedComponent {
    */
   constructor(private service: FormService) {
     if (!service.form.contains(this.key)) {
-      this.tab = new TabWsfedForm(service.registeredService as WSFederationRegisterdService);
+      this.tab = new TabWsfedForm(service.registeredService as WSFederationRegisteredService);
     }
   }
 }

--- a/webapp/cas-mgmt-webapp-workspace/projects/mgmt-lib/src/lib/tab/tab-wsfed/tab-wsfed.form.ts
+++ b/webapp/cas-mgmt-webapp-workspace/projects/mgmt-lib/src/lib/tab/tab-wsfed/tab-wsfed.form.ts
@@ -1,5 +1,5 @@
 import {FormGroup} from '@angular/forms';
-import {WSFederationRegisterdService, AbstractRegisteredService} from '@apereo/mgmt-lib/src/lib/model';
+import {WSFederationRegisteredService, AbstractRegisteredService} from '@apereo/mgmt-lib/src/lib/model';
 import {MgmtFormGroup, WsfedclientForm} from '@apereo/mgmt-lib/src/lib/form';
 
 /**
@@ -12,7 +12,7 @@ export class TabWsfedForm extends FormGroup implements MgmtFormGroup<AbstractReg
   get wsfed() { return this.get('wsfed') as WsfedclientForm; }
   set wsfed(c: WsfedclientForm) { this.setControl('wsfed', c); }
 
-  constructor(private service: WSFederationRegisterdService) {
+  constructor(private service: WSFederationRegisteredService) {
     super({});
     this.reset();
   }
@@ -30,6 +30,6 @@ export class TabWsfedForm extends FormGroup implements MgmtFormGroup<AbstractReg
    * @param service - AbstractRegisteredService
    */
   map(service: AbstractRegisteredService) {
-    this.wsfed.map(service as WSFederationRegisterdService);
+    this.wsfed.map(service as WSFederationRegisteredService);
   }
 }

--- a/webapp/cas-mgmt-webapp-workspace/projects/mgmt-lib/src/lib/ui/app-config.service.ts
+++ b/webapp/cas-mgmt-webapp-workspace/projects/mgmt-lib/src/lib/ui/app-config.service.ts
@@ -9,7 +9,7 @@ import {
   AbstractRegisteredService, OAuthRegisteredService,
   OidcRegisteredService, RegexRegisteredService,
   SamlRegisteredService,
-  WSFederationRegisterdService,
+  WSFederationRegisteredService,
   AppData
 } from '@apereo/mgmt-lib/src/lib/model';
 import {ViewComponent} from './view/view.component';
@@ -87,7 +87,7 @@ export class AppConfigService extends Service {
    * Returns true if the service is an instance of WsFedereationRegisteredService.
    */
   isWsFed(service: AbstractRegisteredService): boolean {
-    return WSFederationRegisterdService.instanceOf(service);
+    return WSFederationRegisteredService.instanceOf(service);
   }
 
   /**

--- a/webapp/cas-mgmt-webapp-workspace/projects/mgmt-lib/src/lib/ui/import.service.ts
+++ b/webapp/cas-mgmt-webapp-workspace/projects/mgmt-lib/src/lib/ui/import.service.ts
@@ -6,7 +6,7 @@ import {
   OAuthRegisteredService,
   OidcRegisteredService,
   SamlRegisteredService,
-  WSFederationRegisterdService
+  WSFederationRegisteredService
 } from '@apereo/mgmt-lib/src/lib/model';
 import {catchError, tap} from 'rxjs/operators';
 import {Service} from './service';
@@ -60,8 +60,8 @@ export class ImportService extends Service {
           if (OidcRegisteredService.instanceOf(resp)) {
             this.service = new OidcRegisteredService(resp);
           }
-          if (WSFederationRegisterdService.instanceOf(resp)) {
-            this.service = new WSFederationRegisterdService(resp);
+          if (WSFederationRegisteredService.instanceOf(resp)) {
+            this.service = new WSFederationRegisteredService(resp);
           }
         }),
         catchError((e) => this.handleError(e, this.dialog))


### PR DESCRIPTION
This fixes an issue where a user was unable to save a WSFed service due to an incorrect classname, and being unable to save any service other than a CAS service when creating a NEW service due to missing properties.