### PR TITLE
Fixed issue with SSO Policy not saving

### DIFF
--- a/webapp/cas-mgmt-webapp-workspace/projects/mgmt-lib/src/lib/field/sso/sso-chain.component.ts
+++ b/webapp/cas-mgmt-webapp-workspace/projects/mgmt-lib/src/lib/field/sso/sso-chain.component.ts
@@ -31,7 +31,7 @@ export class SsoComponent {
    * Cast the form to ChainingSsoForm.
    */
   chaining(): ChainingSsoForm {
-    return this.form.policy as ChainingSsoForm;
+    return this.form.policyForm as ChainingSsoForm;
   }
 
   /**
@@ -64,12 +64,14 @@ export class SsoComponent {
    */
   moveUp() {
     const index = this.selectedPolicy;
-    const chain = this.chaining().policies;
+    const form = this.chaining();
+    const chain = form.policies;
     const up = chain.controls[index];
     chain.controls[index] = chain.controls[index - 1];
     chain.controls[index - 1] = up;
-    chain.markAsTouched();
-    chain.markAsDirty();
+    form.updateValueAndValidity();
+    form.markAsTouched();
+    form.markAsDirty();
   }
 
   /**
@@ -77,12 +79,14 @@ export class SsoComponent {
    */
   moveDown() {
     const index = this.selectedPolicy;
-    const chain = this.chaining().policies;
+    const form = this.chaining();
+    const chain = form.policies;
     const down = chain.controls[index];
     chain.controls[index] = chain.controls[index + 1];
     chain.controls[index + 1] = down;
-    chain.markAsTouched();
-    chain.markAsDirty();
+    form.updateValueAndValidity();
+    form.markAsTouched();
+    form.markAsDirty();
   }
 
   /**
@@ -92,6 +96,8 @@ export class SsoComponent {
    */
   addPolicy(type: SsoPolicyType) {
     this.chaining().policies.push(createSsoForm(ssoParticipationPolicy(null, type)));
+    this.chaining().markAllAsTouched;
+    this.chaining().markAsDirty();
   }
 
 }

--- a/webapp/cas-mgmt-webapp-workspace/projects/mgmt-lib/src/lib/form/sso-policy.form.ts
+++ b/webapp/cas-mgmt-webapp-workspace/projects/mgmt-lib/src/lib/form/sso-policy.form.ts
@@ -94,8 +94,14 @@ export class ChainingSsoForm extends SsoPolicyForm {
 
   constructor(policy: ChainingRegisteredServiceSingleSignOnParticipationPolicy) {
     super({
-      policies: new FormArray([])
+      policies: new FormArray(policy?.policies?.map(p => createSsoForm(p)) || [])
     }, SsoPolicyType.CHAINING);
+  }
+
+  map(): ChainingRegisteredServiceSingleSignOnParticipationPolicy {
+    const policy = new ChainingRegisteredServiceSingleSignOnParticipationPolicy();
+    policy.policies = this.forms.map(c => c.map());
+    return policy;
   }
 }
 


### PR DESCRIPTION
This change fixes an issue where the SSO Policies were not getting saved to the service. Fixing this also uncovered the fact that changes to an SSO policy were not triggering the "save" button to appear in the navbar, so this includes a fix for that issue as well.