### PR TITLE
Log4j version update

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@
 #################################################
 group=org.apereo.cas
 version=6.3.7-SNAPSHOT
-casVersion=6.3.7.1
+casVersion=6.3.7.4
 
 projectUrl=https://github.com:apereo/cas-management
 projectInceptionYear=2004
@@ -64,12 +64,12 @@ javaxServletVersion=4.0.1
 javaxValidationVersion=2.0.1.Final
 javaxJstlVersion=1.2
 
-slf4jVersion=1.7.32
+slf4jVersion=2.0.0-alpha5
 disruptorVersion=3.4.2
 
 jacksonVersion=2.12.0
 groovyVersion=3.0.7
-log4jVersion=2.14.0
+log4jVersion=2.17.0
 thymeleafVersion=3.0.11.RELEASE
 springBootTomcatVersion=9.0.55
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -69,7 +69,7 @@ disruptorVersion=3.4.2
 
 jacksonVersion=2.12.0
 groovyVersion=3.0.7
-log4jVersion=2.17.0
+log4jVersion=2.17.1
 thymeleafVersion=3.0.11.RELEASE
 springBootTomcatVersion=9.0.55
 

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -112,7 +112,7 @@ ext.libraries = [
                 dependencies.create("org.apache.logging.log4j:log4j-web:$log4jVersion") {
                     exclude(group: "org.slf4j", module: "slf4j-api")
                 },
-                dependencies.create("org.apache.logging.log4j:log4j-slf4j-impl:$log4jVersion") {
+                dependencies.create("org.apache.logging.log4j:log4j-slf4j18-impl:$log4jVersion") {
                     exclude(group: "org.slf4j", module: "slf4j-api")
                 },
                 dependencies.create("com.lmax:disruptor:$disruptorVersion")

--- a/gradle/overrides.gradle
+++ b/gradle/overrides.gradle
@@ -18,6 +18,9 @@ configurations.all {
                 if (requested.group == "org.apache.logging.log4j")  {
                     details.useVersion("${log4jVersion}")
                 }
+                if (requested.group == "org.slf4j")  {
+                    details.useVersion("${slf4jVersion}")
+                }
                 if (requested.group == "org.codehaus.groovy")  {
                     details.useVersion("${groovyVersion}")
                 }
@@ -33,7 +36,13 @@ configurations.all {
     exclude(group: "cglib", module: "cglib")
     exclude(group: "cglib", module: "cglib-full")
     exclude(group: "org.slf4j", module: "slf4j-log4j12")
+    //exclude(group: "org.slf4j", module: "slf4j-api")
     exclude(group: "org.slf4j", module: "slf4j-simple")
+    exclude(group: "org.slf4j", module: "jcl-over-slf4j")
+    exclude(group: "org.slf4j", module: "jul-to-slf4j")
     exclude(group: "org.apache.logging.log4j", module: "log4j-to-slf4j")
+    exclude(group: "commons-logging", module: "commons-logging")
     exclude(group: "pull-parser", module: "pull-parser")
 }
+
+ext["log4j2.version"] = ext["log4jVersion"]

--- a/gradle/overrides.gradle
+++ b/gradle/overrides.gradle
@@ -36,7 +36,6 @@ configurations.all {
     exclude(group: "cglib", module: "cglib")
     exclude(group: "cglib", module: "cglib-full")
     exclude(group: "org.slf4j", module: "slf4j-log4j12")
-    //exclude(group: "org.slf4j", module: "slf4j-api")
     exclude(group: "org.slf4j", module: "slf4j-simple")
     exclude(group: "org.slf4j", module: "jcl-over-slf4j")
     exclude(group: "org.slf4j", module: "jul-to-slf4j")


### PR DESCRIPTION
Bumps versions of log4j and slf4j to latest to overcome vulnerability.
Changed config to avoid version conflicts from base cas version or other dependencies