### PR TITLE
Fixed issue where properties form was not populating values

### DIFF
--- a/webapp/cas-mgmt-webapp-workspace/projects/mgmt-lib/src/lib/form/attributes.form.ts
+++ b/webapp/cas-mgmt-webapp-workspace/projects/mgmt-lib/src/lib/form/attributes.form.ts
@@ -43,8 +43,9 @@ export class AttributesForm extends FormArray {
 
   constructor(map?: Map<string, string[] | string>) {
     super([]);
+
     if (map) {
-      map = typeof map === "object" ? new Map(Object.entries(map)) : map;
+      map = (map instanceof Map) ? map : new Map(Object.entries(map));
       for (let key of map.keys()) {
         this.createRow(key, map.get(key) as string[]);
       }


### PR DESCRIPTION
This change fixes a check for a Map in the attributes form that was causing some forms to not be populated when a Map had already been generated.