### PR TITLE
Update TypeScript service default values to match Java

### DIFF
--- a/webapp/cas-mgmt-webapp-workspace/projects/mgmt-lib/src/lib/model/service-model/attribute-provider.model.ts
+++ b/webapp/cas-mgmt-webapp-workspace/projects/mgmt-lib/src/lib/model/service-model/attribute-provider.model.ts
@@ -200,5 +200,8 @@ export function usernameProviderFactory(provider?: any, type?: UserAttributeType
   if (type === UserAttributeType.ANONYMOUS || (!type && AnonymousRegisteredServiceUsernameProvider.instanceOf(provider))) {
     return new AnonymousRegisteredServiceUsernameProvider(provider);
   }
+  if (!type && !provider) {
+    return new DefaultRegisteredServiceUsernameProvider();
+  }
   return provider;
 }

--- a/webapp/cas-mgmt-webapp-workspace/projects/mgmt-lib/src/lib/model/service-model/attribute-release.ts
+++ b/webapp/cas-mgmt-webapp-workspace/projects/mgmt-lib/src/lib/model/service-model/attribute-release.ts
@@ -134,7 +134,7 @@ export class ReturnAllowedAttributeReleasePolicy extends AbstractRegisteredServi
     super(policy);
     const p: ReturnAllowedAttributeReleasePolicy = ReturnAllowedAttributeReleasePolicy.instanceOf(policy)
       ? policy as ReturnAllowedAttributeReleasePolicy : undefined;
-    this.allowedAttributes = p?.allowedAttributes;
+    this.allowedAttributes = p?.allowedAttributes ?? [];
     this['@class'] = ReturnAllowedAttributeReleasePolicy.cName;
   }
 }
@@ -488,7 +488,7 @@ export function attributeReleaseFactory(policy?: any, type?: ReleasePolicyType):
     return new ChainingAttributeReleasePolicy(policy);
   }
   if (!type && !policy) {
-    return new DenyAllAttributeReleasePolicy();
+    return new ReturnAllowedAttributeReleasePolicy();
   }
   return policy;
 }

--- a/webapp/cas-mgmt-webapp-workspace/projects/mgmt-lib/src/lib/model/service-model/multifactor.model.ts
+++ b/webapp/cas-mgmt-webapp-workspace/projects/mgmt-lib/src/lib/model/service-model/multifactor.model.ts
@@ -33,7 +33,7 @@ export class DefaultRegisteredServiceMultifactorPolicy extends RegisteredService
     const p: DefaultRegisteredServiceMultifactorPolicy = DefaultRegisteredServiceMultifactorPolicy.instanceOf(policy)
       ? policy as DefaultRegisteredServiceMultifactorPolicy : undefined;
     this.multifactorAuthenticationProviders = p?.multifactorAuthenticationProviders;
-    this.failureMode = p?.failureMode;
+    this.failureMode = p?.failureMode ?? 'UNDEFINED';
     this.principalAttributeNameTrigger = p?.principalAttributeNameTrigger;
     this.principalAttributeValueToMatch = p?.principalAttributeValueToMatch;
     this.bypassEnabled = p?.bypassEnabled ?? false;
@@ -87,6 +87,9 @@ export function mfaPolicyFactory(policy?: any, type?: MfaPolicyType): Registered
   }
   if (type === MfaPolicyType.GROOVY  || (!type && GroovyRegisteredServiceMultifactorPolicy.instanceOf(policy))) {
     return new GroovyRegisteredServiceMultifactorPolicy(policy);
+  }
+  if (!type && !policy) {
+    return new DefaultRegisteredServiceMultifactorPolicy();
   }
   return policy;
 }

--- a/webapp/cas-mgmt-webapp-workspace/projects/mgmt-lib/src/lib/model/service-model/oauth-service.model.ts
+++ b/webapp/cas-mgmt-webapp-workspace/projects/mgmt-lib/src/lib/model/service-model/oauth-service.model.ts
@@ -49,8 +49,8 @@ export class OAuthRegisteredService extends RegexRegisteredService {
     this.clientId = s?.clientId;
     this.bypassApprovalPrompt = s?.bypassApprovalPrompt ?? false;
     this.generateRefreshToken = s?.generateRefreshToken ?? false;
-    this.supportedGrantTypes = s?.supportedGrantTypes;
-    this.supportedResponseTypes = s?.supportedResponseTypes;
+    this.supportedGrantTypes = s?.supportedGrantTypes ?? [];
+    this.supportedResponseTypes = s?.supportedResponseTypes ?? [];
     this.jwtAccessToken = s?.jwtAccessToken ?? false;
     this.codeExpirationPolicy = codeExpirationPolicy(s?.codeExpirationPolicy);
     this.accessTokenExpirationPolicy = accessTokenExpirationPolicy(s?.accessTokenExpirationPolicy);
@@ -112,7 +112,7 @@ export class OidcRegisteredService extends OAuthRegisteredService {
     this.userInfoEncryptedResponseEncoding = s?.userInfoEncryptedResponseEncoding;
     this.dynamicallyRegistered = s?.dynamicallyRegistered ?? false;
     this.dynamicRegistrationDateTime = s?.dynamicRegistrationDateTime;
-    this.scopes = s?.scopes;
+    this.scopes = s?.scopes ?? [];
     this.subjectType = s?.subjectType ?? 'PUBLIC';
     this.sectorIdentifierUri = s?.sectorIdentifierUri;
     this.applicationType = s?.applicationType ?? 'web';

--- a/webapp/cas-mgmt-webapp-workspace/projects/mgmt-lib/src/lib/model/service-model/registered-service.model.ts
+++ b/webapp/cas-mgmt-webapp-workspace/projects/mgmt-lib/src/lib/model/service-model/registered-service.model.ts
@@ -99,7 +99,7 @@ export abstract class RegisteredService {
     this.logoutType = service?.logoutType ?? 'BACK_CHANNEL';
     this.accessStrategy = accessStrategyFactory(service?.accessStrategy);
     this.publicKey = service?.publicKey;
-    this.properties = service?.properties;
+    this.properties = service?.properties ?? new Map<string, DefaultRegisteredServiceProperty>();
     this.contacts = contactsFactory(service?.contacts);
     this.expirationPolicy = expirationPolicyFactory(service?.expirationPolicy);
     this.environments = service?.environments;


### PR DESCRIPTION
There's an issue deserialising attributeReleasePolicies on the UI, it assumes a missing attributeReleasePolicy is a DenyAll policy when the default on the server side is a ReturnAllowed policy.  This patch just updates the UI / TypeScript service model default values to match those on the Java side. 
