### PR TITLE
fix: null check in loadUserDefinedScopes to avoid null pointer exception

### DIFF
--- a/core/cas-mgmt-core/src/main/java/org/apereo/cas/mgmt/factory/FormDataFactory.java
+++ b/core/cas-mgmt-core/src/main/java/org/apereo/cas/mgmt/factory/FormDataFactory.java
@@ -182,7 +182,7 @@ public class FormDataFactory {
     }
 
     private void loadUserDefinedScopes(final FormData formData) {
-        if (profile.isPresent() && !profile.get().getUserDefinedScopes().isEmpty()) {
+        if (profile.isPresent() && profile.get().getUserDefinedScopes() != null && !profile.get().getUserDefinedScopes().isEmpty()) {
             val p = profile.get();
             formData.setUserDefinedScopes(p.getUserDefinedScopes());
         }


### PR DESCRIPTION
This null check prevents an exception when a cas profile has been fetched through the discovery endpoint but does not have an initialized collection of user defined scopes.
