### PR TITLE
feat: add a properties flag for dashboard enablement

### DIFF
--- a/api/cas-mgmt-api-configuration/src/main/java/org/apereo/cas/configuration/CasManagementConfigurationProperties.java
+++ b/api/cas-mgmt-api-configuration/src/main/java/org/apereo/cas/configuration/CasManagementConfigurationProperties.java
@@ -107,6 +107,11 @@ public class CasManagementConfigurationProperties implements Serializable {
     private String discoveryEndpointPath = "/actuator/discoveryProfile";
 
     /**
+     * Flag to enable/disable dashboard.
+     */
+    private boolean dashboardEnabled = true;
+
+    /**
      * Properties for version control.
      */
     private VersionControl versionControl = new VersionControl();

--- a/api/cas-mgmt-api-core/src/main/java/org/apereo/cas/mgmt/domain/AppConfig.java
+++ b/api/cas-mgmt-api-core/src/main/java/org/apereo/cas/mgmt/domain/AppConfig.java
@@ -20,6 +20,11 @@ public class AppConfig {
     private String mgmtType;
 
     /**
+     * Flag indicating if admin dashboard is enabled.
+     */
+    private boolean dashboardEnabled;
+
+    /**
      * Flag indicating if version control is enabled.
      */
     private boolean versionControl;

--- a/core/cas-mgmt-core/src/main/java/org/apereo/cas/mgmt/controller/ApplicationDataController.java
+++ b/core/cas-mgmt-core/src/main/java/org/apereo/cas/mgmt/controller/ApplicationDataController.java
@@ -86,6 +86,7 @@ public class ApplicationDataController {
         val config = new AppConfig();
         val formData = formDataFactory.create();
         config.setMgmtType(casProperties.getServiceRegistry().getCore().getManagementType().toString());
+        config.setDashboardEnabled(managementProperties.isDashboardEnabled());
         config.setVersionControl(managementProperties.getVersionControl().isEnabled());
         config.setDelegatedMgmt(managementProperties.getDelegated().isEnabled());
         config.setSyncScript(managementProperties.getVersionControl().getSyncScript() != null);

--- a/webapp/cas-mgmt-webapp-workspace/projects/management/src/app/core/navigation/navigation.component.html
+++ b/webapp/cas-mgmt-webapp-workspace/projects/management/src/app/core/navigation/navigation.component.html
@@ -67,7 +67,7 @@
     <mat-icon>history</mat-icon>
     <ng-container i18n>History</ng-container>
   </a>
-  <a [href]="dashboardUrl" *ngIf="isAdmin()" mat-list-item target="_self">
+  <a [href]="dashboardUrl" *ngIf="isAdmin() && isDashboardEnabled()" mat-list-item target="_self">
     <mat-icon>view_quilt</mat-icon>
     <span i18n>Administration</span>
   </a>

--- a/webapp/cas-mgmt-webapp-workspace/projects/management/src/app/core/navigation/navigation.component.ts
+++ b/webapp/cas-mgmt-webapp-workspace/projects/management/src/app/core/navigation/navigation.component.ts
@@ -67,6 +67,13 @@ export class NavigationComponent {
     return this.appService.config.versionControl;
   }
 
+    /**
+     * Returns true if the app's dashboard is enabled.
+     */
+    isDashboardEnabled(): boolean {
+      return this.appService.config.dashboardEnabled;
+    }
+
   /**
    * Calls the server to sync the management registry to CAS servers using the sync script.
    */

--- a/webapp/cas-mgmt-webapp-workspace/projects/mgmt-lib/src/lib/model/app-model/app-config.model.ts
+++ b/webapp/cas-mgmt-webapp-workspace/projects/mgmt-lib/src/lib/model/app-model/app-config.model.ts
@@ -3,6 +3,7 @@
  */
 export class AppConfig {
   mgmtType = 'DEFAULT';
+  dashboardEnabled: boolean;
   versionControl: boolean;
   delegatedMgmt: boolean;
   syncScript: boolean;


### PR DESCRIPTION
Add a property flag to allow deployers to hide the dashboard from the manage app menu if needed.