### PR TITLE
Fix NPE when attempting to use LDAP to authorize users for cas-management

### DIFF
--- a/config/cas-mgmt-config-authz-ldap/src/main/java/org/apereo/cas/mgmt/config/CasManagementLdapAuthorizationConfiguration.java
+++ b/config/cas-mgmt-config-authz-ldap/src/main/java/org/apereo/cas/mgmt/config/CasManagementLdapAuthorizationConfiguration.java
@@ -29,14 +29,18 @@ public class CasManagementLdapAuthorizationConfiguration {
 
     private static SearchOperation ldapAuthorizationGeneratorUserSearchExecutor(final CasManagementConfigurationProperties managementProperties) {
         val ldapAuthz = managementProperties.getLdap().getLdapAuthz();
-        return LdapUtils.newLdaptiveSearchOperation(ldapAuthz.getBaseDn(), ldapAuthz.getSearchFilter(),
+        SearchOperation operation = LdapUtils.newLdaptiveSearchOperation(ldapAuthz.getBaseDn(), ldapAuthz.getSearchFilter(),
             new ArrayList<>(0), CollectionUtils.wrap(ldapAuthz.getRoleAttribute()));
+        operation.setConnectionFactory(LdapUtils.newLdaptiveConnectionFactory(managementProperties.getLdap()));
+        return operation;
     }
 
     private static SearchOperation ldapAuthorizationGeneratorGroupSearchExecutor(final CasManagementConfigurationProperties managementProperties) {
         val ldapAuthz = managementProperties.getLdap().getLdapAuthz();
-        return LdapUtils.newLdaptiveSearchOperation(ldapAuthz.getGroupBaseDn(), ldapAuthz.getGroupFilter(),
+         SearchOperation operation = LdapUtils.newLdaptiveSearchOperation(ldapAuthz.getGroupBaseDn(), ldapAuthz.getGroupFilter(),
             new ArrayList<>(0), CollectionUtils.wrap(ldapAuthz.getGroupAttribute()));
+        operation.setConnectionFactory(LdapUtils.newLdaptiveConnectionFactory(managementProperties.getLdap()));
+        return operation;
     }
 
     @Bean

--- a/config/cas-mgmt-config-authz-ldap/src/main/java/org/apereo/cas/mgmt/config/CasManagementLdapAuthorizationConfiguration.java
+++ b/config/cas-mgmt-config-authz-ldap/src/main/java/org/apereo/cas/mgmt/config/CasManagementLdapAuthorizationConfiguration.java
@@ -37,7 +37,7 @@ public class CasManagementLdapAuthorizationConfiguration {
 
     private static SearchOperation ldapAuthorizationGeneratorGroupSearchExecutor(final CasManagementConfigurationProperties managementProperties) {
         val ldapAuthz = managementProperties.getLdap().getLdapAuthz();
-         SearchOperation operation = LdapUtils.newLdaptiveSearchOperation(ldapAuthz.getGroupBaseDn(), ldapAuthz.getGroupFilter(),
+        SearchOperation operation = LdapUtils.newLdaptiveSearchOperation(ldapAuthz.getGroupBaseDn(), ldapAuthz.getGroupFilter(),
             new ArrayList<>(0), CollectionUtils.wrap(ldapAuthz.getGroupAttribute()));
         operation.setConnectionFactory(LdapUtils.newLdaptiveConnectionFactory(managementProperties.getLdap()));
         return operation;


### PR DESCRIPTION
<!--

# Contributing

First off, thank you for considering to contribute to CAS. 

# Details

Closes #IssueNumber

Ensure that you include the following:

- [] Brief description of changes applied
- [] Any documentation on how to configure, test
- [] Any possible limitations, side effects, etc
- [] Reference any other pull requests that might be related.

-->

I'm not aware of any issue numbers with this.

This change fixes a NPE when attempting to use ldap for authorization to cas-management.

The LdapUtils.newLdaptiveSearchOperation method doesn't set the LDAP connection factory, and thus when
the SearchOperation is executed, a NPE is thrown when it attempts to establish the connection.

There shouldn't be any side effects as this isn't updating the LDAPUtils, class, though its probable the fix should be made there, but that also lives in the cas repo, and not the cas-management repo.

There shouldn't be any changes to configuration, and testing involves including the module, and configuring the cas-management application to use authz via ldap.

This appears at the surface level to be a problem in the 6.4.x and 6.3.x branches as well..  I'm not sure if those branches are still receiving updates or not.

