### PR TITLE
fix: remove json service registry from default configuration dependen…

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -794,8 +794,6 @@ ext.libraries = [
                         },
                         dependencies.create("org.apereo.cas:cas-server-core-services:$casVersion") {
                         },
-                        dependencies.create("org.apereo.cas:cas-server-support-json-service-registry:$casVersion") {
-                        },
                 ],
                 testCore       : [
                         dependencies.create("org.apereo.cas:cas-server-core-services:$casVersion") {


### PR DESCRIPTION
The choice of which service registry backend to use should be up to the deployer of the management app. By removing the org.apereo.cas:cas-server-support-json-service-registry dependency from the casServer.configuration part of the dependencies.gradle we ensure that the json-service-registry jar will not be included in the deployment unless requested by the deployer in the build.gradle.


