### PR TITLE
fix: remove json service registry from default configuration dependen…

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -794,8 +794,6 @@ ext.libraries = [
                         },
                         dependencies.create("org.apereo.cas:cas-server-core-services:$casVersion") {
                         },
-                        dependencies.create("org.apereo.cas:cas-server-support-json-service-registry:$casVersion") {
-                        },
                 ],
                 testCore       : [
                         dependencies.create("org.apereo.cas:cas-server-core-services:$casVersion") {


### PR DESCRIPTION
Backporting https://github.com/apereo/cas-management/pull/246 to 6.5.x branch.

The change is also valid for branch 6.4.x. Should I open a separate pr?
