### PR TITLE
Fix missing credentials for discoveryProfile

### DIFF
--- a/core/cas-mgmt-core/src/main/java/org/apereo/cas/mgmt/factory/FormDataFactory.java
+++ b/core/cas-mgmt-core/src/main/java/org/apereo/cas/mgmt/factory/FormDataFactory.java
@@ -92,7 +92,8 @@ public class FormDataFactory {
                 .parameters(params)
                 .method(HttpMethod.GET);
             if (StringUtils.isNotBlank(mgmtProperties.getActuatorBasicAuthUsername())) {
-                executionRequestBuilder.basicAuthUsername(mgmtProperties.getActuatorBasicAuthUsername()).basicAuthPassword(mgmtProperties.getActuatorBasicAuthPassword());
+                executionRequestBuilder.basicAuthUsername(mgmtProperties.getActuatorBasicAuthUsername())
+                    .basicAuthPassword(mgmtProperties.getActuatorBasicAuthPassword());
             }
             val execution = executionRequestBuilder.build();
             val response = HttpUtils.execute(execution);

--- a/core/cas-mgmt-core/src/main/java/org/apereo/cas/mgmt/factory/FormDataFactory.java
+++ b/core/cas-mgmt-core/src/main/java/org/apereo/cas/mgmt/factory/FormDataFactory.java
@@ -87,11 +87,14 @@ public class FormDataFactory {
         val params = new HashMap<String, String>();
         val url = casProperties.getServer().getPrefix() + mgmtProperties.getDiscoveryEndpointPath();
         try {
-            val execution = HttpUtils.HttpExecutionRequest.builder()
+            val executionRequestBuilder = HttpUtils.HttpExecutionRequest.builder()
                 .url(url)
                 .parameters(params)
-                .method(HttpMethod.GET)
-                .build();
+                .method(HttpMethod.GET);
+            if (StringUtils.isNotBlank(mgmtProperties.getActuatorBasicAuthUsername())) {
+                executionRequestBuilder.basicAuthUsername(mgmtProperties.getActuatorBasicAuthUsername()).basicAuthPassword(mgmtProperties.getActuatorBasicAuthPassword());
+            }
+            val execution = executionRequestBuilder.build();
             val response = HttpUtils.execute(execution);
             if (response != null) {
                 if (response.getStatusLine().getStatusCode() == HttpStatus.OK.value()) {


### PR DESCRIPTION
The discoveryProfile webservice call in the management application isn't detecting if the endpoint is configured to be authenticated or not.  Looking at how other services did this, I added a check to see of the username is set in the configuration, and if so, add the basic auth credentials to the request in order to.

<!--

# Contributing

First off, thank you for considering to contribute to CAS. 

# Details

Closes #IssueNumber

Ensure that you include the following:

- [] Brief description of changes applied
- [] Any documentation on how to configure, test
- [] Any possible limitations, side effects, etc
- [] Reference any other pull requests that might be related.

-->
