### PR TITLE
Upgrade to CasRegisteredService

### DIFF
--- a/webapp/cas-mgmt-webapp-workspace/projects/mgmt-lib/src/lib/model/service-model/registered-service.model.ts
+++ b/webapp/cas-mgmt-webapp-workspace/projects/mgmt-lib/src/lib/model/service-model/registered-service.model.ts
@@ -117,23 +117,23 @@ export abstract class AbstractRegisteredService extends RegisteredService {
 }
 
 /**
- * Data class for RegexRegisteredService.
+ * Data class for (Regex|CAS)RegisteredService.
  */
 export class RegexRegisteredService extends AbstractRegisteredService {
-  static cName = 'org.apereo.cas.services.RegexRegisteredService';
+  static oldName = 'org.apereo.cas.services.RegexRegisteredService';
+  static newName = 'org.apereo.cas.services.CasRegisteredService';
 
   /**
-   * Returns true if the passed object is an instance of RegexRegisteredService.
+   * Returns true if the passed object is an instance of (Regex|CAS)RegisteredService.
    *
    * @param obj - object to be inspected
    */
   static instanceOf(obj: any): boolean {
-    return obj && obj['@class'] === RegexRegisteredService.cName;
+    return obj && (obj['@class'] === RegexRegisteredService.oldName || obj['@class'] === RegexRegisteredService.newName);
   }
 
   constructor(service?: RegisteredService) {
     super(service);
-    this['@class'] = RegexRegisteredService.cName;
+    this['@class'] = RegexRegisteredService.newName;
   }
 }
-


### PR DESCRIPTION
This PR fixes two problems:

1. CAS services using the type `org.apereo.cas.services.CasRegisteredService` are not properly supported: for that, I changed the method `instanceOf` to support both types
2. If a new CAS service is created, it is of type `org.apereo.cas.services.RegexRegisteredService` while the appropriate type should be: `org.apereo.cas.services.CasRegisteredService`: for that, I changed the `constructor` to use the new type.

Currently, the type `org.apereo.cas.services.RegexRegisteredService` causes the following warning:

```java
WARN [org.apereo.cas.services.RegexRegisteredService] - <CAS has located a service definition type that is now tagged as [RegexRegisteredService]. This registered service definition type is scheduled for removal and should no longer be used for CAS-enabled applications, and MUST be replaced with [org.apereo.cas.services.CasRegisteredService] instead. We STRONGLY advise that you update your service definitions and make the replacement to faciliate future CAS upgrades.>
```

and will be eventually removed.