### PR TITLE
Added locale service atribute

### DIFF
--- a/webapp/cas-mgmt-webapp-workspace/projects/mgmt-lib/src/lib/field/field.module.ts
+++ b/webapp/cas-mgmt-webapp-workspace/projects/mgmt-lib/src/lib/field/field.module.ts
@@ -65,6 +65,7 @@ import {ServicetypeComponent} from './servicetype/servicetype.component';
 import {SsoPolicyComponent} from './sso/policy/sso-policy.component';
 import {SsoComponent} from './sso/sso-chain.component';
 import {ThemeidComponent} from './themeid/themeid.component';
+import {LocaleComponent} from './locale/locale.component';
 import {WsfedclientComponent} from './wsfedclient/wsfedclient.component';
 import {AttributesModule} from './attributes/attributes.module';
 import {AuthenticationPolicyComponent} from "./authn-policy/authn-policy.component";
@@ -145,6 +146,7 @@ import { AcceptableUsagePolicyComponent } from './acceptable-usage-policy/accept
     SsoComponent,
     AuthenticationPolicyComponent,
     ThemeidComponent,
+    LocaleComponent,
     WsfedclientComponent,
     AcceptableUsagePolicyTextComponent,
     AcceptableUsagePolicyMessageCode,
@@ -239,6 +241,7 @@ import { AcceptableUsagePolicyComponent } from './acceptable-usage-policy/accept
     SsoComponent,
     AuthenticationPolicyComponent,
     ThemeidComponent,
+    LocaleComponent,
     WsfedclientComponent,
     AcceptableUsagePolicyTextComponent,
     AcceptableUsagePolicyMessageCode,

--- a/webapp/cas-mgmt-webapp-workspace/projects/mgmt-lib/src/lib/field/locale/locale.component.html
+++ b/webapp/cas-mgmt-webapp-workspace/projects/mgmt-lib/src/lib/field/locale/locale.component.html
@@ -1,0 +1,3 @@
+<lib-text-input [control]="control" label="Locale"
+                toolTip="A token that represents the locale that should be applied to CAS when this service asks for authentication.">
+</lib-text-input>

--- a/webapp/cas-mgmt-webapp-workspace/projects/mgmt-lib/src/lib/field/locale/locale.component.spec.ts
+++ b/webapp/cas-mgmt-webapp-workspace/projects/mgmt-lib/src/lib/field/locale/locale.component.spec.ts
@@ -1,0 +1,28 @@
+/* tslint:disable:no-unused-variable */
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { FormsModule } from '@angular/forms';
+
+import { LocaleComponent } from './locale.component';
+
+describe('LocaleComponent', () => {
+  let component: LocaleComponent;
+  let fixture: ComponentFixture<LocaleComponent>;
+
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [ FormsModule ],
+      declarations: [ LocaleComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(LocaleComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/webapp/cas-mgmt-webapp-workspace/projects/mgmt-lib/src/lib/field/locale/locale.component.ts
+++ b/webapp/cas-mgmt-webapp-workspace/projects/mgmt-lib/src/lib/field/locale/locale.component.ts
@@ -1,0 +1,18 @@
+import {Component, Input} from '@angular/core';
+import {FormControl} from '@angular/forms';
+
+/**
+ * Component to display/update locale for a service.
+ *
+ * @author Martin Buechler
+ */
+@Component({
+  selector: 'lib-locale',
+  templateUrl: './locale.component.html'
+})
+export class LocaleComponent {
+
+  @Input()
+  control: FormControl;
+
+}

--- a/webapp/cas-mgmt-webapp-workspace/projects/mgmt-lib/src/lib/field/public-api.ts
+++ b/webapp/cas-mgmt-webapp-workspace/projects/mgmt-lib/src/lib/field/public-api.ts
@@ -76,6 +76,7 @@ export * from './servicetype/servicetype.component';
 export * from './sso/sso-chain.component';
 export * from './sso/policy/sso-policy.component';
 export * from './themeid/themeid.component';
+export * from './locale/locale.component';
 export * from './uidattrs/uidattrs.component';
 export * from './wsfedattrrelpolocies/wsfedattrrelpolicies.component';
 export * from './wsfedclient/wsfedclient.component';

--- a/webapp/cas-mgmt-webapp-workspace/projects/mgmt-lib/src/lib/model/service-model/registered-service.model.ts
+++ b/webapp/cas-mgmt-webapp-workspace/projects/mgmt-lib/src/lib/model/service-model/registered-service.model.ts
@@ -51,6 +51,7 @@ export abstract class RegisteredService {
   serviceId: string;
   name: string;
   theme: string;
+  locale: string;
   informationUrl: string;
   privacyUrl: string;
   responseType: string;
@@ -80,6 +81,7 @@ export abstract class RegisteredService {
     this.serviceId = service?.serviceId;
     this.name = service?.name;
     this.theme = service?.theme;
+    this.locale = service?.locale;
     this.informationUrl = service?.informationUrl;
     this.privacyUrl = service?.privacyUrl;
     this.responseType = service?.responseType;

--- a/webapp/cas-mgmt-webapp-workspace/projects/mgmt-lib/src/lib/tab/tab-basics/tab-basics.component.html
+++ b/webapp/cas-mgmt-webapp-workspace/projects/mgmt-lib/src/lib/tab/tab-basics/tab-basics.component.html
@@ -11,6 +11,7 @@
     <lib-servicename [control]="tab.serviceName"></lib-servicename>
     <lib-servicedesc [control]="tab.description"></lib-servicedesc>
     <lib-themeid [control]="tab.theme"></lib-themeid>
+    <lib-locale [control]="tab.locale"></lib-locale>
   </lib-card>
   <lib-card heading="Reference Links">
     <lib-logo [control]="tab.logo"></lib-logo>

--- a/webapp/cas-mgmt-webapp-workspace/projects/mgmt-lib/src/lib/tab/tab-basics/tab-basics.form.ts
+++ b/webapp/cas-mgmt-webapp-workspace/projects/mgmt-lib/src/lib/tab/tab-basics/tab-basics.form.ts
@@ -14,6 +14,7 @@ export class TabBasicsForm extends FormGroup implements MgmtFormGroup<AbstractRe
   get serviceName() { return this.get('serviceName') as FormControl; }
   get description() { return this.get('description') as FormControl; }
   get theme() { return this.get('theme') as FormControl; }
+  get locale() { return this.get('locale') as FormControl; }
   get logo() { return this.get('logo') as FormControl; }
   get informationUrl() { return this.get('informationUrl') as FormControl; }
   get privacyUrl() { return this.get('privacyUrl') as FormControl; }
@@ -33,6 +34,7 @@ export class TabBasicsForm extends FormGroup implements MgmtFormGroup<AbstractRe
     this.setControl('serviceName', new FormControl(this.service?.name, Validators.required));
     this.setControl('description', new FormControl(this.service?.description));
     this.setControl('theme', new FormControl(this.service?.theme));
+    this.setControl('locale', new FormControl(this.service?.locale));
     this.setControl('logo', new FormControl(this.service?.logo));
     this.setControl('informationUrl', new FormControl(this.service?.informationUrl));
     this.setControl('privacyUrl', new FormControl(this.service?.privacyUrl));
@@ -50,6 +52,7 @@ export class TabBasicsForm extends FormGroup implements MgmtFormGroup<AbstractRe
     service.name = this.serviceName.value;
     service.description = this.description.value;
     service.theme = this.theme.value;
+    service.locale = this.locale.value;
     service.logo = this.logo.value;
     service.informationUrl = this.informationUrl.value;
     service.privacyUrl = this.privacyUrl.value;


### PR DESCRIPTION
# Details

It should be possible to have a "locale" attribute for every service in the registry, without being removed again on the next saving of this service using cas-management server UI. In the cas-management server UI there is no field yet to view and edit this "locale" attribute. Referring to cas-user mailing list entry https://groups.google.com/a/apereo.org/g/cas-user/c/Aifm1iIbKF8

This PR adds the attribute 'locale' as outlined at https://apereo.github.io/cas/6.6.x/ux/User-Interface-Customization-Localization.html#per-service to be managed by the cas-management server.
The new field 'Locale' is visible in the Basics tab right below the 'Theme' field.


